### PR TITLE
change default project template to 'blank'

### DIFF
--- a/lib/ionic/start.js
+++ b/lib/ionic/start.js
@@ -53,7 +53,7 @@ IonicStartTask.prototype.run = function(ionic) {
   // Grab the target path from the command line, or use this as the app name
   var targetPathName = this.appName;
 
-  var starterProject = argv._[2] || 'tabs';
+  var starterProject = argv._[2] || 'blank';
 
   this.targetPath = path.resolve(this.appName);
 


### PR DESCRIPTION
UNTESTED! (but seems easy enough)

Why is the default layout "tabs" and not "blank"?

It's great to have some more advanced starting themes, but why is the default/fallback "tabs"?

It is important to have some kind of display to don't seem broken, but "blank" has this. 

...I am new to ionic and stumbled across this question while doing the 'getting started' guide where I had to delete the tabs thing to have a clean start. 

I have checked the code back to the introduction of the app themes and didn't find a reason for "tabs" there.
