### PR TITLE
Fix typo in `ionic start` quick tips

### DIFF
--- a/lib/ionic/start.js
+++ b/lib/ionic/start.js
@@ -244,7 +244,7 @@ IonicStartTask.prototype._printQuickHelp = function(projectDirectory) {
   if(this.isCordovaProject) {
     console.log('\n * Add a platform (ios or Android):', 'ionic platform add ios [android]'.info.bold);
     console.log('    Note: iOS development requires OS X currently'.small);
-    console.log('    See the Android Platform Guid for full Android installation instructions:'.small);
+    console.log('    See the Android Platform Guide for full Android installation instructions:'.small);
     console.log('    https://cordova.apache.org/docs/en/3.4.0/guide_platforms_android_index.md.html#Android%20Platform%20Guide'.small);
     console.log('\n * Build your app:', 'ionic build <PLATFORM>'.info.bold);
     console.log('\n * Simulate your app:', 'ionic emulate <PLATFORM>'.info.bold);


### PR DESCRIPTION
Currently the quick tips message says "Android Platform Guid".
