### PR TITLE
Replace link to specific version of Cordova docs

### DIFF
--- a/lib/ionic/start.js
+++ b/lib/ionic/start.js
@@ -245,7 +245,7 @@ IonicStartTask.prototype._printQuickHelp = function(projectDirectory) {
     console.log('\n * Add a platform (ios or Android):', 'ionic platform add ios [android]'.info.bold);
     console.log('    Note: iOS development requires OS X currently'.small);
     console.log('    See the Android Platform Guide for full Android installation instructions:'.small);
-    console.log('    https://cordova.apache.org/docs/en/3.4.0/guide_platforms_android_index.md.html#Android%20Platform%20Guide'.small);
+    console.log('    https://cordova.apache.org/docs/en/edge/guide_platforms_android_index.md.html#Android%20Platform%20Guide'.small);
     console.log('\n * Build your app:', 'ionic build <PLATFORM>'.info.bold);
     console.log('\n * Simulate your app:', 'ionic emulate <PLATFORM>'.info.bold);
     console.log('\n * Run your app on a device:', 'ionic run <PLATFORM>'.info.bold);


### PR DESCRIPTION
Cordova docs link set to "edge" instead of 3.4.0 or 3.5.0 or newer to come
