### PR TITLE
Remove "add" from "ionic platform" command ref

### DIFF
--- a/lib/ionic/start.js
+++ b/lib/ionic/start.js
@@ -242,7 +242,7 @@ IonicStartTask.prototype._printQuickHelp = function(projectDirectory) {
   console.log('\n * Develop in the browser with live reload:', 'ionic serve'.info.bold);
 
   if(this.isCordovaProject) {
-    console.log('\n * Add a platform (ios or Android):', 'ionic platform add ios [android]'.info.bold);
+    console.log('\n * Add a platform (ios or Android):', 'ionic platform ios [android]'.info.bold);
     console.log('    Note: iOS development requires OS X currently'.small);
     console.log('    See the Android Platform Guide for full Android installation instructions:'.small);
     console.log('    https://cordova.apache.org/docs/en/3.4.0/guide_platforms_android_index.md.html#Android%20Platform%20Guide'.small);


### PR DESCRIPTION
Main documentation refer to "ionic platform" with `ionic platform <PLATFORM...>` syntax and not `ionic platform add <PLATFORM...>`
