### PR TITLE
Ionic versions read from bower.json instead of version.json

### DIFF
--- a/lib/ionic/lib.js
+++ b/lib/ionic/lib.js
@@ -37,7 +37,7 @@ IonicLibTask.prototype.run = function(ionic) {
 IonicLibTask.prototype.printLibVersions = function() {
   var self = this;
 
-  var p = path.resolve('www/lib/ionic/version.json');
+  var p = path.resolve('www/lib/ionic/bower.json');
   try {
     self.local = require(p);
     console.log('Local Ionic version: '.bold.green + self.local.version + '  (' + path.resolve('www/lib/ionic/') + ')');


### PR DESCRIPTION
Not sure if this is a bug or not. But in my case i only have the bower.json in www/lib/ionic and not version.json
