### PR TITLE
Update after_prepare hook to match <body> tags which have no attributes

### DIFF
--- a/lib/hooks/after_prepare/010_add_platform_class.js
+++ b/lib/hooks/after_prepare/010_add_platform_class.js
@@ -52,7 +52,7 @@ function addPlatformBodyTag(indexPath, platform) {
 function findBodyTag(html) {
   // get the body tag
   try{
-    return html.match(/<body (.*?)>/gi)[0];
+    return html.match(/<body(?=[\s>])(.*?)>/gi)[0];
   }catch(e){}
 }
 


### PR DESCRIPTION
This fixes issue #74 by adding a non-capturing lookahead which matches either a space or a '>' after the <body> tag.
