### PR TITLE
Add gulp as an explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "event-stream": "3.0.x",
     "finalhandler": "0.2.0",
     "form-data": "0.1.4",
+    "gulp": "~3.8.8",
     "ncp": "0.4.2",
     "npm": "2.1.3",
     "open": "0.0.5",


### PR DESCRIPTION
Since we are using gulp, it shouldn't be assumed that developer has gulp installed.
