### PR TITLE
adds proxy support to the serve command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ Use `ionic serve` to start a local development server for app dev and testing. T
 $ ionic serve [options]
 ```
 
+__Proxies:__
+
+The `serve` command can add some proxies to the http server. This proxies are useful if your are developing in the browser and you need to make calls to an external API. With this feature you can proxy request to the external api through the ionic http server preventing the `No 'Access-Control-Allow-Origin' header is present on the requested resource` error.
+
+In the `ionic.project` file you can add a property with an array of proxies you want to add. The proxies are object with two properties:
+
+* `path`: string that will be matched against the beginning of the incoming request URL.
+* `options`: can be an array or an object. Allows any options that are permitted on the [http](http://nodejs.org/api/http.html#http_http_request_options_callback) request options.
+
+```json
+{
+  "name": "appname",
+  "email": "",
+  "app_id": "",
+  "proxies": [
+    {
+      "path": "/api",
+      "options": "http://my.server.com/api"
+    }
+  ]
+}
+
+```
+
 __Command-line flags/options:__
 
     [--consolelogs|-c] ......  Print app console logs to Ionic CLI
@@ -67,6 +91,7 @@ __Command-line flags/options:__
     [--livereload-port|-i] ..  Live Reload port (35729 default)
     [--nobrowser|-b] ........  Disable launching a browser
     [--nolivereload|-r] .....  Do not start live reload
+    [--noproxy|-x] ..........  Do not add proxies
 
 
 ## Adding a platform target

--- a/lib/ionic.js
+++ b/lib/ionic.js
@@ -68,7 +68,8 @@ var TASKS = [
       '--port|-p': 'Dev server HTTP port (8100 default)',
       '--livereload-port|-r': 'Live Reload port (35729 default)',
       '--nobrowser|-b': 'Disable launching a browser',
-      '--nolivereload': 'Do not start live reload'
+      '--nolivereload': 'Do not start live reload',
+      '--noproxy|-x': 'Do not add proxies'
     },
     module: './ionic/serve'
   },

--- a/lib/ionic/serve.js
+++ b/lib/ionic/serve.js
@@ -10,7 +10,9 @@ var fs = require('fs'),
     vfs = require('vinyl-fs'),
     request = require('request'),
     IonicProject = require('./project'),
-    Task = require('./task').Task;
+    Task = require('./task').Task,
+    proxyMiddleware = require('proxy-middleware'),
+    url = require('url');
     IonicStats = require('./stats').IonicStats;
 
 var DEFAULT_HTTP_PORT = 8100;
@@ -53,6 +55,8 @@ IonicTask.prototype.loadSettings = function(cb) {
 
   this.launchBrowser = !argv.nobrowser && !argv.b;
   this.runLivereload = !argv.nolivereload && !argv.r;
+  this.useProxy = !argv.noproxy && !argv.x;
+  this.proxies = project.get('proxies') || [];
   this.watchSass = project.get('sass') === true && !argv.nosass && !argv.n;
   this.gulpStartupTasks = project.get('gulpStartupTasks');
   this.watchPatterns = project.get('watchPatterns') || ['www/**/*', '!www/lib/**/*'];
@@ -172,6 +176,17 @@ IonicTask.prototype.start = function(ionic) {
         port: this.liveReloadPort
       }));
     }
+
+    if(this.useProxy) {
+
+      for(var x=0; x<this.proxies.length; x++) {
+        var proxy = this.proxies[x];
+
+        app.use(proxy.path, proxyMiddleware(url.parse(proxy.options)));
+        console.log('Proxy added:'.green.bold, proxy.path + " => " + url.format(proxy.options));
+      }
+    }
+
 
     this.devServer = this.host(this.port);
 

--- a/lib/ionic/stats.js
+++ b/lib/ionic/stats.js
@@ -542,6 +542,7 @@ exports.IonicStats = {
         '-w': '--no-cordova',
         '-b': '--nobrowser',
         '-r': '--nolivereload',
+        '-x': '--noproxy',
         '-l': '--livereload',
         '-c': '--consolelogs',
         '-s': '--serverlogs',
@@ -557,7 +558,7 @@ exports.IonicStats = {
       }
 
       var platformWhitelist = 'android ios firefoxos wp7 wp8 amazon-fireos blackberry10 tizen'.split(' ');
-      var argsWhitelist = 'add remove list update check debug release search --livereload --consolelogs --serverlogs --no-cordova --nobrowser --nolivereload --no-email --debug --release --device --emulator --sass'.split(' ');
+      var argsWhitelist = 'add remove list update check debug release search --livereload --consolelogs --serverlogs --no-cordova --nobrowser --nolivereload --noproxy --no-email --debug --release --device --emulator --sass'.split(' ');
 
       // collect only certain args, skip over everything else
       for(x=0; x<cmdArgs.length; x++) {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "optimist": "0.6.0",
     "prompt": "0.2.12",
     "progress": "1.1.7",
+    "proxy-middleware": "^0.7.0",
     "q": "1.0.1",
     "request": "2.27.0",
     "serve-static": "1.6.1",


### PR DESCRIPTION
This PR enables the serve command to proxy your api server though the ionic server. This way you don't have the cross origin problems while you develop in the browser

For example to proxy all request to `http://localhost:8100/api` to `http://my.server.com/api`

I hope this is useful for everyone..
