### PR TITLE
Use serve-static@1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "progress": "1.1.7",
     "q": "1.0.1",
     "request": "2.27.0",
-    "serve-static": "1.6.1",
+    "serve-static": "1.7.1",
     "shelljs": "0.2.6",
     "tiny-lr-fork": "0.0.5",
     "unzip": "0.1.9",


### PR DESCRIPTION
serve-static 1.6.1 creates the following error when launching a dev server:

```
/home/spike/.nvm/v0.11.14/lib/node_modules/ionic/node_modules/serve-static/node_modules/send/node_modules/etag/index.js:55
    throw new TypeError('argument entity must be string, Buffer, or fs.Stats')
      ^
TypeError: argument entity must be string, Buffer, or fs.Stats
    at etag (/home/spike/.nvm/v0.11.14/lib/node_modules/ionic/node_modules/serve-static/node_modules/send/node_modules/etag/index.js:
55:11)
    at SendStream.setHeader (/home/spike/.nvm/v0.11.14/lib/node_modules/ionic/node_modules/serve-static/node_modules/send/index.js:72
4:15)
    at SendStream.send (/home/spike/.nvm/v0.11.14/lib/node_modules/ionic/node_modules/serve-static/node_modules/send/index.js:500:8)
    at onstat (/home/spike/.nvm/v0.11.14/lib/node_modules/ionic/node_modules/serve-static/node_modules/send/index.js:585:10)
    at Object.oncomplete (fs.js:93:15)
```

server-static@1.7.1 works fine.

Config:
Ubuntu 14.04 - x64
nvm 0.11.14
ionic 1.2.8
