### PR TITLE
refactor(config): set request timeout instead of deadline timeout.

### DIFF
--- a/packages/cli-plugin-cordova/src/commands/resources.ts
+++ b/packages/cli-plugin-cordova/src/commands/resources.ts
@@ -190,7 +190,8 @@ export class ResourcesCommand extends Command implements CommandPreRun {
 
     // Upload images to service to prepare for resource transformations
     let imageUploadResponses: ImageUploadResponse[];
-    const timeout = config.cliFlags.timeout ? 25000 : 0;
+    const timeout = config.cliFlags.timeout;
+
     imageUploadResponses = await uploadSourceImages(srcImagesAvailable, timeout);
     this.env.log.debug(`${chalk.green('uploadSourceImages')} completed - responses=${JSON.stringify(imageUploadResponses, null, 2)}`);
 

--- a/packages/cli-plugin-cordova/src/lib/__tests__/resources.ts
+++ b/packages/cli-plugin-cordova/src/lib/__tests__/resources.ts
@@ -303,7 +303,7 @@ describe('@ionic/cli-plugin-cordova', () => {
         imageId: '60278b0fa1d5abf43d07c5ae0f8a0b41'
       }];
 
-      const response = await resources.uploadSourceImages(sourceImages, 0);
+      const response = await resources.uploadSourceImages(sourceImages, false);
       expect(response).toEqual([{
         Error: '',
         Width: 337,
@@ -340,7 +340,7 @@ describe('@ionic/cli-plugin-cordova', () => {
         dest: path.join(__dirname, 'fixtures', 'drawable-land-ldpi-screen.png')
       };
 
-      await resources.transformResourceImage(imgResource, 0);
+      await resources.transformResourceImage(imgResource, false);
 
       expect(cliUtils.writeStreamToFile).toHaveBeenCalledWith(
         createRequestMock, imgResource.dest

--- a/packages/cli-plugin-cordova/src/lib/resources.ts
+++ b/packages/cli-plugin-cordova/src/lib/resources.ts
@@ -159,11 +159,11 @@ export function findMostSpecificImage(imageResource: ImageResource, srcImagesAva
  * Upload the provided source image through the resources web service. This will make it available
  * for transforms for the next 5 minutes.
  */
-export async function uploadSourceImages(srcImages: SourceImage[], timeout: number): Promise<ImageUploadResponse[]> {
+export async function uploadSourceImages(srcImages: SourceImage[], timeout: boolean | undefined): Promise<ImageUploadResponse[]> {
   return Promise.all(
     srcImages.map(async (srcImage) => {
       const res = await createRequest('POST', UPLOAD_URL)
-        .timeout(timeout)
+        .timeout({ response: timeout ? 120000 : 0 })
         .type('form')
         .attach('src', srcImage.path)
         .field('image_id', srcImage.imageId || '');
@@ -176,10 +176,10 @@ export async function uploadSourceImages(srcImages: SourceImage[], timeout: numb
  * Using the transformation web service transform the provided image resource
  * into the appropiate w x h and then write this file to the provided destination directory.
  */
-export function transformResourceImage(imageResource: ImageResource, timeout: number) {
+export function transformResourceImage(imageResource: ImageResource, timeout: boolean | undefined) {
   return new Promise<void>((resolve, reject) => {
     const req = createRequest('POST', TRANSFORM_URL)
-      .timeout(timeout)
+      .timeout({ response: timeout ? 120000 : 0 })
       .type('form')
       .send({
         'name': imageResource.name,

--- a/packages/ionic/src/commands/start.ts
+++ b/packages/ionic/src/commands/start.ts
@@ -273,7 +273,7 @@ export class StartCommand extends Command implements CommandPreRun {
     this.env.tasks.end();
     this.env.log.info(`Fetching app base (${chalk.dim(wrapperBranchPath)})`);
     const d1Task = this.env.tasks.next('Downloading');
-    const timeout = config.cliFlags.timeout ? 25000 : 0;
+    const timeout = config.cliFlags.timeout;
 
     await tarXvfFromUrl(wrapperBranchPath, projectRoot, timeout, { progress: (loaded, total) => {
       d1Task.progress(loaded, total);

--- a/packages/ionic/src/lib/start.ts
+++ b/packages/ionic/src/lib/start.ts
@@ -17,10 +17,10 @@ import {
 
 import { StarterTemplate, StarterTemplateType } from '../definitions';
 
-export function tarXvfFromUrl(url: string, destination: string, timeout: number, { progress }: {  progress?: (loaded: number, total: number) => void }) {
+export function tarXvfFromUrl(url: string, destination: string, timeout: boolean | undefined, { progress }: {  progress?: (loaded: number, total: number) => void }) {
   return new Promise<void>((resolve, reject) => {
     const archiveRequest = createRequest('get', url)
-      .timeout(timeout)
+      .timeout({ response: timeout ? 120000 : 0 })
       .on('response', (res) => {
         if (res.statusCode !== 200) {
           reject(new Error(`Encountered bad status code (${res.statusCode}) for ${url}\n` +

--- a/types/superagent.d.ts
+++ b/types/superagent.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for SuperAgent v2.0.0
+// Type definitions for SuperAgent v3.5.1
 // Project: https://github.com/visionmedia/superagent
 // Definitions by: Alex Varju <https://github.com/varju/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -118,7 +118,7 @@ declare module "superagent" {
         send(): this;
         set(field: string, val: string): this;
         set(field: Object): this;
-        timeout(ms: number): this;
+        timeout(ms: number | Object | { response: number, read: number, deadline: number }): this;
         type(val: string): this;
         unset(field: string): this;
         use(fn: Function): this;


### PR DESCRIPTION
This changes applies a `request timeout` that waits for server response, instead of the default `deadline timeout` that waits for the entire thread.