### PR TITLE
feat(cloud): add options for snapshot metadata

### DIFF
--- a/packages/cli-utils/src/lib/deploy.ts
+++ b/packages/cli-utils/src/lib/deploy.ts
@@ -53,7 +53,7 @@ export class DeployClient {
     return res.data;
   }
 
-  async requestSnapshotUpload(options: { legacy_duplication?: string; note?: string } = {}): Promise<DeploySnapshotRequest> {
+  async requestSnapshotUpload(options: { legacy_duplication?: string; note?: string; user_metadata?: Object } = {}): Promise<DeploySnapshotRequest> {
     options.legacy_duplication = '1';
 
     const req = this.client.make('POST', '/deploy/snapshots')
@@ -64,6 +64,17 @@ export class DeployClient {
 
     if (!isDeploySnapshotRequestResponse(res)) {
       throw createFatalAPIFormat(req, res);
+    }
+
+    // TODO: Remove updateMetaDataReq when POST -> deploy/snapshots accepts user_metadata
+    if (options.user_metadata) {
+      const updateMetaDataReq = this.client.make('PATCH', `/deploy/snapshots/${res.data.uuid}`)
+        .set('Authorization', `Bearer ${this.appUserToken}`)
+        .send({
+          'user_metadata': options.user_metadata
+        });
+
+      await this.client.do(updateMetaDataReq);
     }
 
     return res.data;

--- a/packages/ionic/src/commands/upload.ts
+++ b/packages/ionic/src/commands/upload.ts
@@ -26,6 +26,10 @@ From there, you can use Ionic View (${chalk.bold('https://view.ionic.io')}) to e
       description: 'Give this snapshot a nice description',
     },
     {
+      name: 'metadata',
+      description: 'set metadata properties for this snapshot',
+    },
+    {
       name: 'deploy',
       description: 'Deploys this snapshot to the given channel',
     },
@@ -45,6 +49,14 @@ export class UploadCommand extends Command {
     return input;
   }
 
+  resolveMetaData(input: CommandLineInput) {
+    if (typeof input !== 'string') {
+      input = undefined;
+    }
+
+    return input ? JSON.parse(input) : undefined;
+  }
+
   resolveChannelTag(input: CommandLineInput) {
     if (typeof input !== 'string') {
       input = undefined;
@@ -58,6 +70,7 @@ export class UploadCommand extends Command {
   async run(inputs: CommandLineInputs, options: CommandLineOptions): Promise<void> {
     const note = this.resolveNote(options['note']);
     const channelTag = this.resolveChannelTag(options['deploy']);
+    const user_metadata = this.resolveMetaData(options['metadata']);
 
     if (!options['nobuild']) {
       await this.env.hooks.fire('command:build', {
@@ -68,7 +81,7 @@ export class UploadCommand extends Command {
       });
     }
 
-    await upload(this.env, { note, channelTag });
+    await upload(this.env, { note, channelTag, user_metadata });
   }
 
 }

--- a/packages/ionic/src/lib/upload.ts
+++ b/packages/ionic/src/lib/upload.ts
@@ -10,7 +10,7 @@ import {
   createArchive,
 } from '@ionic/cli-utils';
 
-export async function upload(env: IonicEnvironment, { note, channelTag }: { note?: string, channelTag?: string }): Promise<DeploySnapshotRequest> {
+export async function upload(env: IonicEnvironment, { note, channelTag, user_metadata }: { note?: string, channelTag?: string, user_metadata?: Object}): Promise<DeploySnapshotRequest> {
   let channel: DeployChannel | undefined;
 
   const token = await env.session.getAppUserToken();
@@ -27,7 +27,7 @@ export async function upload(env: IonicEnvironment, { note, channelTag }: { note
   zip.finalize();
 
   env.tasks.next('Requesting snapshot upload');
-  const snapshot = await deploy.requestSnapshotUpload({ note });
+  const snapshot = await deploy.requestSnapshotUpload({ note, user_metadata });
   const uploadTask = env.tasks.next('Uploading snapshot');
   await deploy.uploadSnapshot(snapshot, zip, (loaded, total) => {
     uploadTask.progress(loaded, total);


### PR DESCRIPTION
Added options to set snapshot metadata for ionic deploy.

Example usage:
`ionic upload --metadata='{"livereload":true, "version":".170625"}' --note="test metadata" `

Fixes:
https://github.com/ionic-team/ionic-cli/issues/2403, https://github.com/ionic-team/ionic-cli/issues/660, https://github.com/ionic-team/ionic-plugin-deploy/issues/95