### PR TITLE
patch for passing params from lab to iframes

### DIFF
--- a/packages/cli-plugin-ionic1/lab/static/js/lab.js
+++ b/packages/cli-plugin-ionic1/lab/static/js/lab.js
@@ -48,6 +48,13 @@ function showDevice(device, isShowing) {
     var template = $('#' + device + '-frame-template');
     var clone = document.importNode(template, true);
     $('preview').appendChild(clone.content);
+    //check for extra params in location.url to pass on to iframes
+    var params = document.location.href.split('?')
+    if (params) {
+      params = params[params.length - 1]
+      var oldsrc = $('preview .frame').getAttribute('src')
+      $('preview .frame').setAttribute('src', oldsrc + '&' + params)
+    }
   } else {
     rendered.style.display = isShowing ? '' : 'none';
   }

--- a/packages/cli-plugin-ionic1/lab/static/js/lab.js
+++ b/packages/cli-plugin-ionic1/lab/static/js/lab.js
@@ -51,9 +51,9 @@ function showDevice(device, isShowing) {
     //check for extra params in location.url to pass on to iframes
     var params = document.location.href.split('?')
     if (params) {
-      params = params[params.length - 1]
+      var extraparams = params[params.length - 1]
       var oldsrc = $('preview .frame').getAttribute('src')
-      $('preview .frame').setAttribute('src', oldsrc + '&' + params)
+      $('preview .frame').setAttribute('src', oldsrc + '&' + extraparams)
     }
   } else {
     rendered.style.display = isShowing ? '' : 'none';


### PR DESCRIPTION
this little pull request makes the labs (-lab) environment pass all params put on the url to the iframes that run the iphone/android and windows ionic.

this way you can pass ionic params to your app also when running in lab mode.

fix for https://github.com/ionic-team/ionic-cli/issues/2431