### PR TITLE
feat(generators): add module options

### DIFF
--- a/packages/cli-plugin-ionic-angular/package.json
+++ b/packages/cli-plugin-ionic-angular/package.json
@@ -50,7 +50,7 @@
     "@angular/compiler": "^4.2.4",
     "@angular/compiler-cli": "^4.2.4",
     "@angular/core": "^4.2.4",
-    "@ionic/app-scripts": "^2.0.0",
+    "@ionic/app-scripts": "^2.1.0",
     "@ionic/cli-scripts": "0.2.1",
     "@types/chalk": "^0.4.31",
     "@types/clean-css": "^3.4.30",

--- a/packages/cli-plugin-ionic-angular/src/generate.ts
+++ b/packages/cli-plugin-ionic-angular/src/generate.ts
@@ -11,7 +11,7 @@ import {
 import * as AppScriptsType from '@ionic/app-scripts';
 
 import { load } from './lib/modules';
-import { prompt, tabsPrompt } from './utils/generate';
+import { getModules, prompt, tabsPrompt } from './utils/generate';
 
 export async function generate(args: CommandHookArgs): Promise<string[]> {
   if (!args.env.project.directory) {
@@ -37,21 +37,21 @@ export async function generate(args: CommandHookArgs): Promise<string[]> {
   const context = AppScripts.generateContext();
 
   const [ type, name ] = args.inputs;
-
+  const includeNgModule = args.options.module;
   switch (type) {
     case 'page':
-      await AppScripts.processPageRequest(context, name);
+      await AppScripts.processPageRequest(context, name, includeNgModule);
       break;
     case 'component':
-      const componentData = await promptQuestions(context);
+      const componentData = await getModules(context, 'component');
       await AppScripts.processComponentRequest(context, name, componentData);
       break;
     case 'directive':
-      const directiveData = await promptQuestions(context);
+      const directiveData = await getModules(context, 'directive');
       await AppScripts.processDirectiveRequest(context, name, directiveData);
       break;
     case 'pipe':
-      const pipeData = await promptQuestions(context);
+      const pipeData = await getModules(context, 'pipe');
       await AppScripts.processPipeRequest(context, name, pipeData);
       break;
     case 'provider':
@@ -60,7 +60,7 @@ export async function generate(args: CommandHookArgs): Promise<string[]> {
       break;
     case 'tabs':
       const tabsData = await tabsPrompt(args.env);
-      await AppScripts.processTabsRequest(context, name, tabsData);
+      await AppScripts.processTabsRequest(context, name, tabsData, includeNgModule);
       break;
   }
 

--- a/packages/cli-plugin-ionic-angular/src/generate.ts
+++ b/packages/cli-plugin-ionic-angular/src/generate.ts
@@ -38,9 +38,13 @@ export async function generate(args: CommandHookArgs): Promise<string[]> {
 
   const [ type, name ] = args.inputs;
   const includeNgModule = args.options.module;
+  const includePageConstants = args.options.constants;
+
+  // args.env.log.msg(() => `${includePageConstants}`);
+
   switch (type) {
     case 'page':
-      await AppScripts.processPageRequest(context, name, includeNgModule);
+      await AppScripts.processPageRequest(context, name, includeNgModule, includePageConstants);
       break;
     case 'component':
       const componentData = await getModules(context, 'component');
@@ -60,7 +64,7 @@ export async function generate(args: CommandHookArgs): Promise<string[]> {
       break;
     case 'tabs':
       const tabsData = await tabsPrompt(args.env);
-      await AppScripts.processTabsRequest(context, name, tabsData, includeNgModule);
+      await AppScripts.processTabsRequest(context, name, tabsData, includeNgModule, includePageConstants);
       break;
   }
 

--- a/packages/cli-plugin-ionic-angular/src/generate.ts
+++ b/packages/cli-plugin-ionic-angular/src/generate.ts
@@ -37,14 +37,11 @@ export async function generate(args: CommandHookArgs): Promise<string[]> {
   const context = AppScripts.generateContext();
 
   const [ type, name ] = args.inputs;
-  const includeNgModule = args.options.module;
-  const includePageConstants = args.options.constants;
-
-  // args.env.log.msg(() => `${includePageConstants}`);
+  const commandOptions = args.options;
 
   switch (type) {
     case 'page':
-      await AppScripts.processPageRequest(context, name, includeNgModule, includePageConstants);
+      await AppScripts.processPageRequest(context, name, commandOptions);
       break;
     case 'component':
       const componentData = await getModules(context, 'component');
@@ -64,7 +61,7 @@ export async function generate(args: CommandHookArgs): Promise<string[]> {
       break;
     case 'tabs':
       const tabsData = await tabsPrompt(args.env);
-      await AppScripts.processTabsRequest(context, name, tabsData, includeNgModule, includePageConstants);
+      await AppScripts.processTabsRequest(context, name, tabsData, commandOptions);
       break;
   }
 

--- a/packages/cli-plugin-ionic-angular/src/utils/generate.ts
+++ b/packages/cli-plugin-ionic-angular/src/utils/generate.ts
@@ -26,11 +26,11 @@ export async function prompt(context: AppScriptsType.BuildContext) {
 export async function getModules(context: AppScriptsType.BuildContext, kind: string) {
   switch (kind) {
     case 'component':
-      return context.componentsNgModulePath;
+      return context.componentsNgModulePath || context.appNgModulePath;
     case 'pipe':
-      return context.pipesNgModulePath;
+      return context.pipesNgModulePath || context.appNgModulePath;
     case 'directive':
-      return context.directivesNgModulePath;
+      return context.directivesNgModulePath || context.appNgModulePath;
   }
 }
 

--- a/packages/cli-plugin-ionic-angular/src/utils/generate.ts
+++ b/packages/cli-plugin-ionic-angular/src/utils/generate.ts
@@ -23,6 +23,17 @@ export async function prompt(context: AppScriptsType.BuildContext) {
   return context.appNgModulePath;
 }
 
+export async function getModules(context: AppScriptsType.BuildContext, kind: string) {
+  switch (kind) {
+    case 'component':
+      return context.componentsNgModulePath;
+    case 'pipe':
+      return context.pipesNgModulePath;
+    case 'directive':
+      return context.directivesNgModulePath;
+  }
+}
+
 export async function tabsPrompt(env: IonicEnvironment) {
   const tabNames = [];
 

--- a/packages/cli-plugin-ionic-angular/src/utils/generate.ts
+++ b/packages/cli-plugin-ionic-angular/src/utils/generate.ts
@@ -26,11 +26,11 @@ export async function prompt(context: AppScriptsType.BuildContext) {
 export async function getModules(context: AppScriptsType.BuildContext, kind: string) {
   switch (kind) {
     case 'component':
-      return context.componentsNgModulePath || context.appNgModulePath;
+      return context.componentsNgModulePath ? context.componentsNgModulePath : context.appNgModulePath;
     case 'pipe':
-      return context.pipesNgModulePath || context.appNgModulePath;
+      return context.pipesNgModulePath ? context.pipesNgModulePath : context.appNgModulePath;
     case 'directive':
-      return context.directivesNgModulePath || context.appNgModulePath;
+      return context.directivesNgModulePath ? context.directivesNgModulePath : context.appNgModulePath;
   }
 }
 

--- a/packages/ionic/src/commands/generate.ts
+++ b/packages/ionic/src/commands/generate.ts
@@ -41,6 +41,12 @@ The given ${chalk.green('name')} is normalized into an appropriate naming conven
       description: 'Skip generating a NgModule',
       type: Boolean,
       default: true
+    },
+    {
+      name: 'constants',
+      description: 'Generate a page constant files for lazy loaded pages',
+      type: Boolean,
+      default: false
     }
   ]
 })

--- a/packages/ionic/src/commands/generate.ts
+++ b/packages/ionic/src/commands/generate.ts
@@ -35,6 +35,14 @@ The given ${chalk.green('name')} is normalized into an appropriate naming conven
       description: 'The name of the component being generated',
     }
   ],
+  options: [
+    {
+      name: 'module',
+      description: 'Skip generating a NgModule',
+      type: Boolean,
+      default: true
+    }
+  ]
 })
 export class GenerateCommand extends Command implements CommandPreRun {
   async preRun(inputs: CommandLineInputs, options: CommandLineOptions): Promise<void | number> {

--- a/packages/ionic/src/commands/generate.ts
+++ b/packages/ionic/src/commands/generate.ts
@@ -23,7 +23,15 @@ Automatically create components for your Ionic app.
 
 The given ${chalk.green('name')} is normalized into an appropriate naming convention. For example, ${chalk.green('ionic generate page neat')} creates a page by the name of ${chalk.green('NeatPage')} in ${chalk.green('src/pages/neat/')}.
   `,
-  exampleCommands: ['', ...TYPE_CHOICES, 'component foo', 'page Login', 'pipe MyFilterPipe'],
+  exampleCommands: [
+    '',
+    ...TYPE_CHOICES,
+    'component foo',
+    'page Login',
+    'page Detail --no-module',
+    'page About --constants',
+    'pipe MyFilterPipe'
+  ],
   inputs: [
     {
       name: 'type',
@@ -103,7 +111,7 @@ export class GenerateCommand extends Command implements CommandPreRun {
   }
 
   async run(inputs: CommandLineInputs, options: CommandLineOptions): Promise<void> {
-    const [ type, name ] = inputs;
+    const [type, name] = inputs;
 
     await this.env.hooks.fire('command:generate', { cmd: this, env: this.env, inputs, options }); // TODO: print generated templates
 


### PR DESCRIPTION
Adds `module` and `no-module` flags to the CLI

Requires https://github.com/ionic-team/ionic-app-scripts/pull/1141 to be merged first