### PR TITLE
docs(readme): make service proxy json more real

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ you want to add. The proxies are object with the following properties:
 ```json
 {
   "name": "appname",
-  "email": "",
   "app_id": "",
+  "type": "ionic-angular",
   "proxies": [
     {
       "path": "/v1",


### PR DESCRIPTION
CLI adds "type" attribute, "email" isn't normally present.