### PR TITLE
docs(readme): replace :heart:

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Use `ionic --help` for more detailed command information.
 Page](https://ionicframework.com/support) for general support questions. The
 issues on GitHub should be reserved for bug reports and feature requests.
 
-:heart: **Want to contribute?** Please see
+:sparkling_heart: **Want to contribute?** Please see
 [CONTRIBUTING.md](https://github.com/ionic-team/ionic-cli/blob/master/CONTRIBUTING.md).
 
 ## Table of Contents ##


### PR DESCRIPTION
with :sparkling_heart: because it is rendered properly on Windows as well.
:heart: is sometimes quite strange, see diff:
![image](https://user-images.githubusercontent.com/183673/28522206-64a50e4e-7077-11e7-82d0-0f6cfaad85e1.png)
