### PR TITLE
docs(index): add trailing slash to command links

### DIFF
--- a/packages/cli-scripts/docs.js
+++ b/packages/cli-scripts/docs.js
@@ -61,7 +61,7 @@ function formatIonicPage(env) {
       return;
     }
 
-    return `[${cmdData.fullName}](${path.join(...cmdData.fullName.split(' '))}) | ${stripAnsi(cmdData.description)}`;
+    return `[${cmdData.fullName}](${path.join(...cmdData.fullName.split(' '))}/) | ${stripAnsi(cmdData.description)}`;
   }
 
   const commands = getCmds(env);


### PR DESCRIPTION
fixes the problem that each command link first has to redirected to the version with trailing slash

closes https://github.com/ionic-team/ionic-site/issues/1227