### PR TITLE
fix cordova "build after hook"

### DIFF
--- a/packages/@ionic/cli-utils/src/commands/build.ts
+++ b/packages/@ionic/cli-utils/src/commands/build.ts
@@ -12,5 +12,5 @@ export async function build(env: IonicEnvironment, inputs: CommandLineInputs, op
     await build({ env, options: { platform, ...options } });
   }
 
-  await env.hooks.fire('build:after', { env });
+  await env.hooks.fire('build:after', { env, platform });
 }

--- a/packages/ionic/src/index.ts
+++ b/packages/ionic/src/index.ts
@@ -68,7 +68,7 @@ export function registerHooks(hooks: IHookEngine) {
     }
   });
 
-  hooks.register(name, BUILD_AFTER_HOOK, async ({ env }) => {
+  hooks.register(name, BUILD_AFTER_HOOK, async ({ env, platform }) => {
     const [ project, packageJson ] = await Promise.all([env.project.load(), env.project.loadPackageJson()]);
 
     if (packageJson.scripts && packageJson.scripts[BUILD_AFTER_SCRIPT]) {
@@ -85,7 +85,7 @@ export function registerHooks(hooks: IHookEngine) {
     }
 
     if (project.integrations.cordova && project.integrations.cordova.enabled !== false) {
-      await env.runcmd(['cordova', 'prepare']);
+      await env.runcmd(['cordova', 'prepare', platform]);
     }
   });
 


### PR DESCRIPTION
`cordova prepare` is called without the `platform` argument, breaking
platform specific builds.