### PR TITLE
feat(generators): add --minimal flag

### DIFF
--- a/packages/@ionic/cli-utils/src/lib/ionic-angular/generate.ts
+++ b/packages/@ionic/cli-utils/src/lib/ionic-angular/generate.ts
@@ -19,6 +19,7 @@ export async function generate(args: { env: IonicEnvironment; inputs: string[], 
   const commandOptions = {
     module: false,
     constants: false,
+    minimal: false,
   };
 
   if (args.options['module']) {
@@ -27,6 +28,10 @@ export async function generate(args: { env: IonicEnvironment; inputs: string[], 
 
   if (args.options['constants']) {
     commandOptions.constants = true;
+  }
+  
+  if (args.options['minimal']) {
+    commandOptions.minimal = true;
   }
 
   switch (type) {

--- a/packages/ionic/src/commands/generate.ts
+++ b/packages/ionic/src/commands/generate.ts
@@ -52,7 +52,7 @@ The given ${chalk.green('name')} is normalized into an appropriate naming conven
     },
     {
       name: 'minimal',
-      description: 'Only generate what is necessary. No comments or lifecycle hooks',
+      description: 'Only generate what is necessary. No comments, no lifecycle hooks, no module, no spec, inline template.',
       type: Boolean,
       default: false
     }

--- a/packages/ionic/src/commands/generate.ts
+++ b/packages/ionic/src/commands/generate.ts
@@ -52,7 +52,7 @@ The given ${chalk.green('name')} is normalized into an appropriate naming conven
     },
     {
       name: 'minimal',
-      description: 'Only generate what is necessary. No comments, no lifecycle hooks, no testing spec.',
+      description: 'Only generate what is necessary. No comments or lifecycle hooks',
       type: Boolean,
       default: false
     }

--- a/packages/ionic/src/commands/generate.ts
+++ b/packages/ionic/src/commands/generate.ts
@@ -48,6 +48,12 @@ The given ${chalk.green('name')} is normalized into an appropriate naming conven
       description: 'Generate a page constant file for lazy-loaded pages',
       type: Boolean,
       default: false
+    },
+    {
+      name: 'minimal',
+      description: 'Only generate what is necessary. No comments, no lifecycle hooks, no spec.',
+      type: Boolean,
+      default: false
     }
   ]
 })

--- a/packages/ionic/src/commands/generate.ts
+++ b/packages/ionic/src/commands/generate.ts
@@ -23,6 +23,7 @@ The given ${chalk.green('name')} is normalized into an appropriate naming conven
     'page Login',
     'page Detail --no-module',
     'page About --constants',
+    'component special-button --minimal',
     'pipe MyFilterPipe'
   ],
   inputs: [
@@ -51,7 +52,7 @@ The given ${chalk.green('name')} is normalized into an appropriate naming conven
     },
     {
       name: 'minimal',
-      description: 'Only generate what is necessary. No comments, no lifecycle hooks, no spec.',
+      description: 'Only generate what is necessary. No comments, no lifecycle hooks, no testing spec.',
       type: Boolean,
       default: false
     }


### PR DESCRIPTION
#### Short description of what this resolves:
I want to implement a flag for the [generate](https://ionicframework.com/docs/cli/generate/) command that uses alternative templates that only include the bare minimum copypasta. Inspired from the`--minimal` flag in the [angular-cli](https://github.com/angular/angular-cli/wiki/new).

##### The things I would omit would be:
- auto generated comments i.e. "Generated template for the ... "
- `ionViewDidLoad()` console log
- spec
- ngModule
- separate html template file (use inline template instead)

But I'm open to suggestions about what else could be altered to be more "minimal". These are just the things that I often delete straight away when I use the generator, so I'd love to automate this.

#### Changes proposed in this pull request:
##### For `ionic-cli` repo:
- add minimal flag to request object
- and metadata/description for the flag

##### For `ionic-app-scripts` repo:
- add constant for `.minimal` pre extension in `ionic-app-scripts/src/generators/constants.ts`
- add to skip logic in the `filterOutTemplates() `function in `ionic-app-scripts/src/generators/util.ts`

##### For `ionic` repo:
- Add minimal `ts.minimal.tmpl` files for all modules except tabs

**Refactors**:
- removed a comma from the page template in `ionic/scripts/templates/page/ts.tmpl` for consistency with other templates