### PR TITLE
Minor changes to make npm commands run on Windows -- Issue #2967

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,22 +5,16 @@
     "clean": "lerna run clean",
     "lint": "lerna run lint",
     "lint:fix": "lerna run lint -- -- --fix",
-    "link":
-      "lerna exec --scope=ionic --scope=\"@ionic/+(lab|v1-util)\" npm link",
-    "unlink":
-      "lerna exec --scope=ionic --scope=\"@ionic/+(lab|v1-util)\" npm unlink",
+    "link": "lerna exec --scope=ionic --scope=\"@ionic/+(lab|v1-util)\" npm link",
+    "unlink": "lerna exec --scope=ionic --scope=\"@ionic/+(lab|v1-util)\" npm unlink",
     "test": "lerna run test",
     "build": "lerna run build",
     "watch": "lerna run watch --parallel",
     "docs": "node packages/@ionic/cli-scripts/bin/ionic-cli-scripts docs",
-    "docs:watch":
-      "chokidar 'packages/@ionic/cli-scripts/dist/docs/**/*.js' -c 'npm run docs'",
-    "publish:canary":
-      "lerna publish --canary --exact --npm-tag=canary --skip-git",
-    "publish:ci-4.x":
-      "lerna publish --canary --exact --npm-tag=canary --skip-git --cd-version=major",
-    "publish:testing":
-      "lerna publish --canary=testing --exact --npm-tag=testing --skip-git",
+    "docs:watch": "chokidar 'packages/@ionic/cli-scripts/dist/docs/**/*.js' -c 'npm run docs'",
+    "publish:canary": "lerna publish --canary --exact --npm-tag=canary --skip-git",
+    "publish:ci-4.x": "lerna publish --canary --exact --npm-tag=canary --skip-git --cd-version=major",
+    "publish:testing": "lerna publish --canary=testing --exact --npm-tag=testing --skip-git",
     "publish": "lerna publish --exact --conventional-commits",
     "prepush": "npm run lint"
   },

--- a/package.json
+++ b/package.json
@@ -5,16 +5,22 @@
     "clean": "lerna run clean",
     "lint": "lerna run lint",
     "lint:fix": "lerna run lint -- -- --fix",
-    "link": "lerna exec --scope=ionic --scope='@ionic/+(lab|v1-util)' npm link",
-    "unlink": "lerna exec --scope=ionic --scope='@ionic/+(lab|v1-util)' npm unlink",
+    "link":
+      "lerna exec --scope=ionic --scope=\"@ionic/+(lab|v1-util)\" npm link",
+    "unlink":
+      "lerna exec --scope=ionic --scope=\"@ionic/+(lab|v1-util)\" npm unlink",
     "test": "lerna run test",
     "build": "lerna run build",
     "watch": "lerna run watch --parallel",
     "docs": "node packages/@ionic/cli-scripts/bin/ionic-cli-scripts docs",
-    "docs:watch": "chokidar 'packages/@ionic/cli-scripts/dist/docs/**/*.js' -c 'npm run docs'",
-    "publish:canary": "lerna publish --canary --exact --npm-tag=canary --skip-git",
-    "publish:ci-4.x": "lerna publish --canary --exact --npm-tag=canary --skip-git --cd-version=major",
-    "publish:testing": "lerna publish --canary=testing --exact --npm-tag=testing --skip-git",
+    "docs:watch":
+      "chokidar 'packages/@ionic/cli-scripts/dist/docs/**/*.js' -c 'npm run docs'",
+    "publish:canary":
+      "lerna publish --canary --exact --npm-tag=canary --skip-git",
+    "publish:ci-4.x":
+      "lerna publish --canary --exact --npm-tag=canary --skip-git --cd-version=major",
+    "publish:testing":
+      "lerna publish --canary=testing --exact --npm-tag=testing --skip-git",
     "publish": "lerna publish --exact --conventional-commits",
     "prepush": "npm run lint"
   },

--- a/packages/@ionic/cli-framework/package.json
+++ b/packages/@ionic/cli-framework/package.json
@@ -10,7 +10,7 @@
     "node": ">=6.4.0"
   },
   "scripts": {
-    "clean": "rm -rf index.* definitions.* guards.* ./lib ./utils",
+    "clean": "rimraf index.* definitions.* guards.* ./lib ./utils",
     "lint": "tslint --config ../../../tslint.js --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w",

--- a/packages/@ionic/cli-plugin-proxy/package.json
+++ b/packages/@ionic/cli-plugin-proxy/package.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "name": "@ionic/cli-plugin-proxy",
   "version": "1.5.6",
   "description": "Ionic CLI plugin for proxying all CLI HTTP requests",
@@ -7,7 +7,7 @@
   "main": "./dist/index.js",
   "types": "./dist/main.d.ts",
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "lint": "tslint --config ../../../tslint.js --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w",
@@ -57,5 +57,9 @@
     "@ionic/cli-utils": "1.19.0",
     "superagent-proxy": "^1.0.2",
     "tslib": "^1.9.0"
+  },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
   }
 }
+

--- a/packages/@ionic/cli-scripts/package.json
+++ b/packages/@ionic/cli-scripts/package.json
@@ -1,8 +1,8 @@
-{
+﻿{
   "name": "@ionic/cli-scripts",
   "version": "0.3.7",
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "lint": "tslint --config ../../../tslint.js --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w",
@@ -24,7 +24,8 @@
   "devDependencies": {
     "@types/ansi-styles": "^2.0.30",
     "@types/escape-string-regexp": "0.0.32",
-    "@types/strip-ansi": "^3.0.0"
+    "@types/strip-ansi": "^3.0.0",
+    "rimraf": "^2.6.2"
   },
   "jest": {
     "globals": {
@@ -42,3 +43,4 @@
     "testRegex": "/__tests__/.*\\.(ts|js)$"
   }
 }
+

--- a/packages/@ionic/cli-utils/package.json
+++ b/packages/@ionic/cli-utils/package.json
@@ -7,7 +7,7 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "scripts": {
-    "clean": "rm -rf index.* bootstrap.* constants.* definitions.* guards.* ./lib ./commands",
+    "clean": "rimraf index.* bootstrap.* constants.* definitions.* guards.* ./lib ./commands",
     "lint": "tslint --config ../../../tslint.js --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w",
@@ -73,7 +73,8 @@
     "@types/split2": "^2.1.6",
     "@types/tar": "^4.0.0",
     "@types/through2": "^2.0.33",
-    "@types/uuid": "^3.4.3"
+    "@types/uuid": "^3.4.3",
+    "rimraf": "^2.6.2"
   },
   "optionalDependencies": {
     "superagent-proxy": "^1.0.2"

--- a/packages/@ionic/discover/package.json
+++ b/packages/@ionic/discover/package.json
@@ -13,7 +13,7 @@
     "README.md"
   ],
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "lint": "tslint --config ../../../tslint.js --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w",
@@ -25,7 +25,8 @@
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@types/netmask": "^1.0.30"
+    "@types/netmask": "^1.0.30",
+    "rimraf": "^2.6.2"
   },
   "repository": {
     "type": "git",

--- a/packages/@ionic/lab/package.json
+++ b/packages/@ionic/lab/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "@ionic/lab",
   "version": "0.0.0",
   "description": "Ionic Lab utility for developing Ionic apps, used by Ionic CLI",
@@ -66,4 +66,3 @@
     "testRegex": "/__tests__/.*\\.(ts|js)$"
   }
 }
-

--- a/packages/@ionic/lab/package.json
+++ b/packages/@ionic/lab/package.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "name": "@ionic/lab",
   "version": "0.0.0",
   "description": "Ionic Lab utility for developing Ionic apps, used by Ionic CLI",
@@ -19,8 +19,8 @@
   ],
   "scripts": {
     "clean": "npm run clean.tsc",
-    "clean.tsc": "rm -rf ./dist",
-    "clean.stencil": "rm -rf ./www",
+    "clean.tsc": "rimraf ./dist",
+    "clean.stencil": "rimraf ./www",
     "lint": "tslint --config ../../../tslint.js --project tsconfig.json",
     "build": "npm run build.tsc && npm run build.stencil",
     "build.stencil": "npm run clean.stencil && stencil build",
@@ -40,7 +40,8 @@
     "@stencil/core": "^0.1.6",
     "@stencil/dev-server": "0.0.18",
     "@types/express": "^4.11.0",
-    "concurrently": "^3.5.1"
+    "concurrently": "^3.5.1",
+    "rimraf": "^2.6.2"
   },
   "repository": {
     "type": "git",
@@ -65,3 +66,4 @@
     "testRegex": "/__tests__/.*\\.(ts|js)$"
   }
 }
+

--- a/packages/@ionic/schematics-angular/package.json
+++ b/packages/@ionic/schematics-angular/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://ionicframework.com/",
   "author": "Ionic Team <hi@ionic.io> (https://ionicframework.com) ",
   "scripts": {
-    "clean": "rm -rf */index.{js,d.ts}",
+    "clean": "rimraf */index.{js,d.ts}",
     "lint": "tslint --config ../../../tslint.js --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w",
@@ -27,6 +27,7 @@
     "@angular-devkit/core": "0.0.28",
     "@angular-devkit/schematics": "0.0.51",
     "@types/lodash": "^4.14.93",
+    "rimraf": "^2.6.2",
     "source-map": "^0.7.0"
   },
   "peerDependencies": {

--- a/packages/@ionic/v1-util/package.json
+++ b/packages/@ionic/v1-util/package.json
@@ -18,7 +18,7 @@
     "README.md"
   ],
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "lint": "tslint --config ../../../tslint.js --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w",
@@ -42,7 +42,8 @@
     "@types/express": "^4.11.0",
     "@types/gulp": "^3.8.36",
     "@types/http-proxy-middleware": "^0.17.2",
-    "@types/ws": "^3.2.1"
+    "@types/ws": "^3.2.1",
+    "rimraf": "^2.6.2"
   },
   "optionalDependencies": {
     "gulp": "^3.9.1"


### PR DESCRIPTION
Fix is for Issue #2967 

-- Replaced all 'rm -rf' with rimraf
-- Replaced single quote in lerna exec npm script with double quote to make Windows happy