### PR TITLE
import local @angular-devkit/schematics

### DIFF
--- a/packages/@ionic/cli-utils/src/lib/project/angular/generate.ts
+++ b/packages/@ionic/cli-utils/src/lib/project/angular/generate.ts
@@ -208,8 +208,8 @@ ${chalk.cyan('[1]')}: ${chalk.bold('https://ionicframework.com/docs/cli/projects
   private async getSchematics(): Promise<Schematic[]> {
     if (!this.schematics) {
       try {
-        const { SchematicEngine } = await import('@angular-devkit/schematics');
-        const { NodeModulesEngineHost } = await import('@angular-devkit/schematics/tools');
+        const { SchematicEngine } = await import( process.cwd() + '/node_modules/@angular-devkit/schematics');
+        const { NodeModulesEngineHost } = await import( process.cwd() + '/node_modules/@angular-devkit/schematics/tools');
 
         const engineHost = new NodeModulesEngineHost();
         const engine = new SchematicEngine(engineHost);


### PR DESCRIPTION
Default import @angular-devkit/schematics use global one.

https://github.com/ionic-team/starters/commit/155d3f6ce4f8c8a95317df683409050d06457d00 commit is locally. so change import directory.

https://github.com/ionic-team/ionic-cli/issues/3019#issuecomment-375528179