### PR TITLE
fix(generate): use local @angular-devkit/schematics/tools

### DIFF
--- a/packages/@ionic/cli-utils/src/lib/project/angular/angular-devkit.ts
+++ b/packages/@ionic/cli-utils/src/lib/project/angular/angular-devkit.ts
@@ -9,7 +9,7 @@ export async function importNgSchematics(projectDir: string): Promise<typeof Ang
 }
 
 export async function importNgSchematicsTools(projectDir: string): Promise<typeof AngularDevKitSchematicsToolsType> {
-  const p = resolve('@angular-devkit/schematics/tools', { paths: compileNodeModulesPaths(projectDir) });
+  const p = resolve('@angular-devkit/schematics/tools/index.js', { paths: compileNodeModulesPaths(projectDir) });
   return require(p);
 }
 


### PR DESCRIPTION
This is https://github.com/ionic-team/ionic-cli/pull/3027 's bug fix.

resolve( https://github.com/ionic-team/ionic-cli/blob/master/packages/%40ionic/cli-framework/src/utils/npm.ts#L72 ) needs `package.json` in case path is folder.
So specify index.js.