### PR TITLE
change default styleext scss

### DIFF
--- a/packages/@ionic/schematics-angular/page/schema.json
+++ b/packages/@ionic/schematics-angular/page/schema.json
@@ -32,7 +32,7 @@
     "styleext": {
       "type": "string",
       "description": "The file extension of the style file for the page",
-      "default": "css"
+      "default": "scss"
     },
     "spec": {
       "type": "boolean",


### PR DESCRIPTION
generate page(Angular CLI collection) is check schema.json (not check project .angular-cli.json)
so I think cli should change styleext default.