### PR TITLE
when generate page, add page entryComponents

### DIFF
--- a/packages/@ionic/schematics-angular/page/index.ts
+++ b/packages/@ionic/schematics-angular/page/index.ts
@@ -15,13 +15,13 @@ import {
   url,
 } from '@angular-devkit/schematics';
 
-import { addDeclarationToModule } from '../utils/angular/ast-utils';
+import { addDeclarationToModule, addEntryComponentsToModule } from '../utils/angular/ast-utils';
 import { InsertChange } from '../utils/angular/change';
 import { buildRelativePath, findModuleFromOptions } from '../utils/angular/find-module';
 
 import { Schema as PageOptions } from './schema';
 
-function addDeclarationToNgModule(options: PageOptions): Rule {
+function addPageToNgModule(utils: 'Declaration'|'EntryComponents', options: PageOptions): Rule {
   const { module } = options;
 
   if (!module) {
@@ -46,16 +46,26 @@ function addDeclarationToNgModule(options: PageOptions): Rule {
 
     const relativePath = buildRelativePath(module, pagePath);
     const classifiedName = `${upperFirst(camelCase(options.name))}Page`;
-    const declarationChanges = addDeclarationToModule(source, module, classifiedName, relativePath);
-    const declarationRecorder = host.beginUpdate(module);
 
-    for (const change of declarationChanges) {
-      if (change instanceof InsertChange) {
-        declarationRecorder.insertLeft(change.pos, change.toAdd);
-      }
+    let addNgModuleMethod: Function;
+    if (utils === 'Declaration') {
+        addNgModuleMethod = addDeclarationToModule;
+    } else if (utils === 'EntryComponents') {
+        addNgModuleMethod = addEntryComponentsToModule;
+    } else {
+        throw new SchematicsException('add module method is not found.');
     }
 
-    host.commitUpdate(declarationRecorder);
+    const Changes = addNgModuleMethod(source, module, classifiedName, relativePath);
+    const Recorder = host.beginUpdate(module);
+
+    for (const change of Changes) {
+        if (change instanceof InsertChange) {
+            Recorder.insertLeft(change.pos, change.toAdd);
+        }
+    }
+
+    host.commitUpdate(Recorder);
 
     return host;
   };
@@ -89,7 +99,8 @@ export default function (options: PageOptions): Rule {
 
     return chain([
       branchAndMerge(chain([
-        addDeclarationToNgModule(options),
+        addPageToNgModule('Declaration', options),
+        addPageToNgModule('EntryComponents', options),
         mergeWith(templateSource),
       ])),
     ])(host, context);

--- a/packages/@ionic/schematics-angular/utils/angular/ast-utils.ts
+++ b/packages/@ionic/schematics-angular/utils/angular/ast-utils.ts
@@ -388,6 +388,17 @@ export function addDeclarationToModule(source: ts.SourceFile,
 }
 
 /**
+ * Custom function to insert a entryComponents (page)
+ * into NgModule declarations. It also imports the component.
+ */
+export function addEntryComponentsToModule(source: ts.SourceFile,
+                                       modulePath: string, classifiedName: string,
+                                       importPath: string): Change[] {
+    return addSymbolToNgModuleMetadata(
+        source, modulePath, 'entryComponents', classifiedName, importPath);
+}
+
+/**
  * Custom function to insert an NgModule into NgModule imports. It also imports the module.
  */
 export function addImportToModule(source: ts.SourceFile,


### PR DESCRIPTION
When using NavController in no LazyLoading, target Page must be registered ngModule entryComponents.
I add function `ionic generate page` add ngModule entryComponents.