### PR TITLE
fix(serve): remove progress cli flag

### DIFF
--- a/packages/@ionic/cli-utils/src/lib/project/angular/serve.ts
+++ b/packages/@ionic/cli-utils/src/lib/project/angular/serve.ts
@@ -222,7 +222,6 @@ ${chalk.cyan('[2]')}: ${chalk.bold('https://github.com/angular/angular-cli/wiki/
       _: [],
       host: options.address,
       port: String(options.port),
-      progress: 'false',
       target: options.target,
       environment: options.environment,
       ssl: options.ssl ? 'true' : undefined,


### PR DESCRIPTION
This removes the `progress` flag from the CLI arguments in an Angular v6 project. 