### PR TITLE
fix(page-schematics): remove ion-page

### DIFF
--- a/packages/@ionic/schematics-angular/page/files/__name@kebabCase@if-flat__/__name@kebabCase__.page.html
+++ b/packages/@ionic/schematics-angular/page/files/__name@kebabCase@if-flat__/__name@kebabCase__.page.html
@@ -1,11 +1,9 @@
-<ion-page>
-  <ion-header>
-    <ion-toolbar>
-      <ion-title><%= name %></ion-title>
-    </ion-toolbar>
-  </ion-header>
+<ion-header>
+  <ion-toolbar>
+    <ion-title><%= name %></ion-title>
+  </ion-toolbar>
+</ion-header>
 
-  <ion-content padding>
+<ion-content padding>
 
-  </ion-content>
-</ion-page>
+</ion-content>


### PR DESCRIPTION
When generating a new page for an Ionic 4 project, the following error is generated:

```
compiler.js:215 Uncaught Error: Template parse errors:
'ion-page' is not a known element:
1. If 'ion-page' is an Angular component, then verify that it is part of this module.
2. If 'ion-page' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message. ("[ERROR ->]<ion-page>
<ion-header>
  <ion-toolbar>
```

I believe this will fix that and make the page consistent with the pages generated by the starters.