### PR TITLE
Generator Updates

### DIFF
--- a/packages/@ionic/cli-utils/src/lib/project/angular/generate.ts
+++ b/packages/@ionic/cli-utils/src/lib/project/angular/generate.ts
@@ -9,51 +9,54 @@ import { GLOBAL_OPTIONS } from '../../config';
 import { FatalException } from '../../errors';
 import { GenerateRunner } from '../../generate';
 
+// https://github.com/ionic-team/ionic-cli/blob/develop/packages/%40ionic/schematics-angular/collection.json
 const SCHEMATICS: ReadonlyArray<string> = ['page', 'component', 'service', 'module', 'class', 'directive', 'guard', 'pipe', 'interface', 'enum'];
+const SCHEMATIC_ALIAS = new Map<string, string>([
+  ['pg', 'page'],
+  ['cl', 'class'],
+  ['c', 'component'],
+  ['d', 'directive'],
+  ['e', 'enum'],
+  ['g', 'guard'],
+  ['i', 'interface'],
+  ['m', 'module'],
+  ['p', 'pipe'],
+  ['s', 'service'],
+]);
 
 const debug = Debug('ionic:cli-utils:lib:project:angular:generate');
-
-function examplePath(type: string): string {
-  if (['page', 'component', 'service', 'directive', 'pipe'].includes(type)) {
-    return `${type}s/<name>`;
-  }
-
-  return 'path/to/<name>';
-}
 
 export class AngularGenerateRunner extends GenerateRunner<AngularGenerateOptions> {
   async getCommandMetadata(): Promise<Partial<CommandMetadata>> {
     return {
       groups: [CommandGroup.Beta],
       description: `
-This command uses the Angular CLI to generate ${['pages', 'components', 'directives', 'services'].map(c => chalk.green(c)).join(', ')}, etc.
+This command uses the Angular CLI to generate features such as ${['pages', 'components', 'directives', 'services'].map(c => chalk.green(c)).join(', ')}, etc.
 
  - For a full list of available types, use ${chalk.green('npx ng g --help')}
  - For a list of options for a types, use ${chalk.green('npx ng g <type> --help')}
 
-We recommend prefixing ${chalk.green('name')} with a consistent, descriptive path within ${chalk.bold('src/app/')}, otherwise the app will quickly become cluttered. For example, for ${chalk.green('pages')}, try ${chalk.green('ionic g page pages/my-new-page')}.
-
-You can nest components deeper inside other components. For example, specify a name of ${chalk.green('pages/tabs-page/tab1')} to generate page files at ${chalk.bold('src/app/pages/tabs-page/tab1/')}.
+You can specify a path to nest your feature within any number of subdirectories. For example, specify a name of ${chalk.green('"pages/New Page"')} to generate page files at ${chalk.bold('src/app/pages/new-page/')}.
 
 To test a generator before file modifications are made, use the ${chalk.green('--dry-run')} option.
       `,
       exampleCommands: [
         'page',
-        'page pages/contact',
-        'component pages/contact/form',
-        'component components/login-form --change-detection=OnPush',
-        'directive directives/ripple --skip-import',
-        'service services/api/user',
+        'page contact',
+        'component contact/form',
+        'component login-form --change-detection=OnPush',
+        'directive ripple --skip-import',
+        'service api/user',
       ],
       inputs: [
         {
           name: 'type',
-          summary: `The type of generator (e.g. ${['page', 'component', 'directive', 'service'].map(c => chalk.green(c)).join(', ')})`,
+          summary: `The type of feature (e.g. ${['page', 'component', 'directive', 'service'].map(c => chalk.green(c)).join(', ')})`,
           validators: [validators.required],
         },
         {
           name: 'name',
-          summary: 'The name of the component being generated',
+          summary: 'The name/path of the feature being generated',
           validators: [validators.required],
         },
       ],
@@ -73,10 +76,11 @@ To test a generator before file modifications are made, use the ${chalk.green('-
     }
 
     if (!inputs[1]) {
+      const type = SCHEMATIC_ALIAS.get(inputs[0]) || inputs[0];
       const name = await this.prompt({
         type: 'input',
         name: 'name',
-        message: `Name/path (e.g. ${chalk.green(examplePath(inputs[0]))}):`,
+        message: `Name/path of ${chalk.green(type)}:`,
         validate: v => validators.required(v),
       });
 
@@ -97,7 +101,8 @@ To test a generator before file modifications are made, use the ${chalk.green('-
   }
 
   async run(options: AngularGenerateOptions) {
-    const { type, name } = options;
+    const { name } = options;
+    const type = SCHEMATIC_ALIAS.get(options.type) || options.type;
 
     try {
       await this.generateComponent(type, name, lodash.omit(options, 'type', 'name'));

--- a/packages/ionic/src/commands/generate.ts
+++ b/packages/ionic/src/commands/generate.ts
@@ -32,7 +32,7 @@ export class GenerateCommand extends Command implements CommandPreRun {
     return {
       name: 'generate',
       type: 'project',
-      summary: 'Automatically create framework components',
+      summary: 'Automatically create framework features',
       description,
       inputs,
       options,


### PR DESCRIPTION
There is a disparity between our starters and `ionic generate`. Our generators do not _force_ the `pages/` & `components/` prefix to the name, but all our starters have pages within a `pages/` folder, so when `ionic generate` is used for the first time, it generates a page outside the `pages/` folder, which is weird.

These updates suppress our (previously) heavy recommendation of prefixing pages with `pages/`, and opens it up to users' preferences, as Angular has no strong opinions on this, either.

See the updates in our starters here: https://github.com/ionic-team/starters/pull/341

cc @mlynch 