### PR TITLE
fix(cli-framework/utils): catch connected socket.

### DIFF
--- a/packages/@ionic/cli-framework/src/utils/network.ts
+++ b/packages/@ionic/cli-framework/src/utils/network.ts
@@ -84,6 +84,11 @@ export async function isHostConnectable(host: string, port: number, { timeout }:
         resolve(true);
       });
 
+      if (sock.connecting === true) {
+        sock.destroy();
+        resolve(true);
+      }
+
       sock.on('error', err => {
         reject(err);
       });


### PR DESCRIPTION
when don't get `sock.on('connect')` Event, `if (sock.connecting === true)` get connected status. 
It worked well in my environment.

Fixes https://github.com/ionic-team/ionic-cli/issues/3410