### PR TITLE
fix(cli-utils/project): pass the host address as it is

### DIFF
--- a/packages/@ionic/cli-utils/src/lib/project/angular/serve.ts
+++ b/packages/@ionic/cli-utils/src/lib/project/angular/serve.ts
@@ -104,7 +104,7 @@ ${chalk.cyan('[1]')}: ${chalk.bold('https://github.com/angular/angular-cli/wiki/
       this.e.log.info(`Waiting for connectivity with ${chalk.green(program)}...`);
     }, 5000);
 
-    await isHostConnectable('localhost', ngPort);
+    await isHostConnectable(options.address, ngPort);
     clearInterval(interval);
 
     return {

--- a/packages/@ionic/cli-utils/src/lib/project/ionic-angular/serve.ts
+++ b/packages/@ionic/cli-utils/src/lib/project/ionic-angular/serve.ts
@@ -126,7 +126,7 @@ export class IonicAngularServeRunner extends ServeRunner<IonicAngularServeOption
       this.e.log.info(`Waiting for connectivity with ${chalk.green(program)}...`);
     }, 5000);
 
-    await isHostConnectable('localhost', port);
+    await isHostConnectable(options.address, port);
     clearInterval(interval);
 
     return {

--- a/packages/@ionic/cli-utils/src/lib/project/ionic1/serve.ts
+++ b/packages/@ionic/cli-utils/src/lib/project/ionic1/serve.ts
@@ -105,7 +105,7 @@ export class Ionic1ServeRunner extends ServeRunner<Ionic1ServeOptions> {
       this.e.log.info(`Waiting for connectivity with ${chalk.green(program)}...`);
     }, 5000);
 
-    await isHostConnectable('localhost', port);
+    await isHostConnectable(options.address, port);
     clearInterval(interval);
 
     return {


### PR DESCRIPTION
Fixes https://github.com/ionic-team/ionic-cli/issues/3410

Change `await isHostConnectable('localhost', port);` to `await isHostConnectable(options.address, port);` .  I think this is consistent `findOpenIonicPorts()`'s address.

---
- cause of my error
'localhost' can't resolve ip-address.
reference: https://github.com/nodejs/node/issues/2237#issuecomment-124718020

- cause of https://github.com/ionic-team/ionic-cli/issues/3410#issuecomment-408444428
change address `192.168.254.58`, but connect check by `localhost`.
