### PR TITLE
fix(cli-framework/network): change 0.0.0.0 to 127.0.0.1

### DIFF
--- a/packages/@ionic/cli-framework/src/utils/network.ts
+++ b/packages/@ionic/cli-framework/src/utils/network.ts
@@ -131,6 +131,10 @@ export function isPortAvailableForHost(host: string, port: number): Promise<bool
 export async function isHostConnectable(host: string, port: number, { timeout }: { timeout?: number; } = {}): Promise<boolean> {
   const tryConnect = async () => {
     return new Promise<boolean>((resolve, reject) => {
+      if (host === '0.0.0.0') {
+        host = '127.0.0.1';
+      }
+
       const sock = net.connect({ port, host });
 
       sock.on('connect', () => {


### PR DESCRIPTION
if check host connection, not use 0.0.0.0. Maybe DevApp not use this method.

Fix: https://github.com/ionic-team/ionic-cli/issues/3473