### PR TITLE
fix(ng-toolkit): no display angular_devkit path error

### DIFF
--- a/packages/@ionic/ng-toolkit/tsconfig.json
+++ b/packages/@ionic/ng-toolkit/tsconfig.json
@@ -6,5 +6,9 @@
   "exclude": [
     "node_modules",
     "src/**/__tests__/*.ts"
-  ]
+  ],
+  // Fix: https://github.com/angular/angular-cli/issues/11992
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
 }


### PR DESCRIPTION
https://github.com/angular/angular-cli/issues/11992.

Now Angular CLI version Only. Next version will fix.