### PR TITLE
fix(lab): remove css that places the statusbar above the header

### DIFF
--- a/packages/@ionic/lab/src/stencil/components/ionlab-device-frame/ionlab-device-frame.css
+++ b/packages/@ionic/lab/src/stencil/components/ionlab-device-frame/ionlab-device-frame.css
@@ -70,18 +70,8 @@ ionlab-device-frame .frame-container iframe {
   background-image: url('/assets/ios-statusbar.png');
 }
 
-#device-android .frame-container iframe {
-  margin-top: 20px;
-  height: calc(var(--frame-height) - 20px);
-}
-
 #device-android .frame-container .statusbar {
   background-image: url('/assets/android-statusbar.png');
-}
-
-#device-windows .frame-container iframe {
-  margin-top: 20px;
-  height: calc(var(--frame-height) - 20px);
 }
 
 #device-windows .frame-container .statusbar {

--- a/packages/@ionic/lab/src/stencil/components/ionlab-preview/ionlab-preview.tsx
+++ b/packages/@ionic/lab/src/stencil/components/ionlab-preview/ionlab-preview.tsx
@@ -27,10 +27,7 @@ export class Preview {
       }
     } else if (this.projectType === 'ionic-angular') {
       qp['ionicplatform'] = platform;
-
-      if (platform === PLATFORM_IOS) {
-        qp['ionicstatusbarpadding'] = 'true';
-      }
+      qp['ionicstatusbarpadding'] = 'true';
     }
 
     return `${this.url}?${Object.keys(qp).map(k => `${encodeURIComponent(k)}=${encodeURIComponent(qp[k])}`).join('&')}`;


### PR DESCRIPTION
fixes android and windows statusbar so it is on top of the header in lab

references #3069 

before:
![localhost_8200_](https://user-images.githubusercontent.com/6577830/49169405-abf3c380-f307-11e8-9be1-a089e2d5dd52.png)


aftah:
![localhost_8200_ 1](https://user-images.githubusercontent.com/6577830/49169412-ae561d80-f307-11e8-824c-672191e00b01.png)
