### PR TITLE
Add allow attribute to ionlab-device-frame iframe

### DIFF
--- a/packages/@ionic/lab/src/stencil/components/ionlab-device-frame/ionlab-device-frame.tsx
+++ b/packages/@ionic/lab/src/stencil/components/ionlab-device-frame/ionlab-device-frame.tsx
@@ -39,7 +39,7 @@ export class DeviceFrame {
         <div class="statusbar" />
         { !this.loaded && !this.error ? <sk-fading-circle /> : null }
         { this.error ? <div class="load-error"><h3>Load Timeout</h3><p>Still trying...</p></div> : null }
-        <iframe src={ this.url } onLoad={ event => this.loadedHandler(event) } />
+        <iframe src={ this.url } onLoad={ event => this.loadedHandler(event) } allow="geolocation; microphone; camera; midi; encrypted-media"/>
       </div>
     ];
   }


### PR DESCRIPTION
Fixes #3781
Issue was introduced by Chrome version of 30th November.

Feature policy: https://wicg.github.io/feature-policy/#iframe-allow-attribute
Spec: https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes