### PR TITLE
chore(lint): replace tslint.js with tslint.json

### DIFF
--- a/packages/@ionic/cli-framework/package.json
+++ b/packages/@ionic/cli-framework/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "clean": "rimraf index.* definitions.* errors.* guards.* lib utils",
-    "lint": "tslint --config tslint.js --project tsconfig.json",
+    "lint": "tslint --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",

--- a/packages/@ionic/cli-framework/tslint.js
+++ b/packages/@ionic/cli-framework/tslint.js
@@ -1,3 +1,0 @@
-module.exports = {
-  "extends": "../../../tslint.base",
-};

--- a/packages/@ionic/cli-framework/tslint.json
+++ b/packages/@ionic/cli-framework/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tslint.base.json"
+}

--- a/packages/@ionic/discover/package.json
+++ b/packages/@ionic/discover/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --config tslint.js --project tsconfig.json",
+    "lint": "tslint --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",

--- a/packages/@ionic/discover/tslint.js
+++ b/packages/@ionic/discover/tslint.js
@@ -1,3 +1,0 @@
-module.exports = {
-  "extends": "../../../tslint.base",
-};

--- a/packages/@ionic/discover/tslint.json
+++ b/packages/@ionic/discover/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tslint.base.json"
+}

--- a/packages/@ionic/lab/package.json
+++ b/packages/@ionic/lab/package.json
@@ -28,7 +28,7 @@
     "clean": "npm run clean.tsc",
     "clean.tsc": "rimraf dist",
     "clean.stencil": "rimraf www",
-    "lint": "tslint --config tslint.js --project tsconfig.json",
+    "lint": "tslint --project tsconfig.json",
     "build": "npm run build.tsc && npm run build.stencil",
     "build.stencil": "npm run clean.stencil && stencil build",
     "build.tsc": "npm run clean.tsc && tsc",

--- a/packages/@ionic/lab/tslint.js
+++ b/packages/@ionic/lab/tslint.js
@@ -1,3 +1,0 @@
-module.exports = {
-  "extends": "../../../tslint.base",
-};

--- a/packages/@ionic/lab/tslint.json
+++ b/packages/@ionic/lab/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tslint.base.json"
+}

--- a/packages/@ionic/utils-fs/package.json
+++ b/packages/@ionic/utils-fs/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --config tslint.js --project tsconfig.json",
+    "lint": "tslint --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",

--- a/packages/@ionic/utils-fs/tslint.js
+++ b/packages/@ionic/utils-fs/tslint.js
@@ -1,3 +1,0 @@
-module.exports = {
-  "extends": "../../../tslint.base",
-};

--- a/packages/@ionic/utils-fs/tslint.json
+++ b/packages/@ionic/utils-fs/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tslint.base.json"
+}

--- a/packages/@ionic/utils-network/package.json
+++ b/packages/@ionic/utils-network/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --config tslint.js --project tsconfig.json",
+    "lint": "tslint --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",

--- a/packages/@ionic/utils-network/tslint.js
+++ b/packages/@ionic/utils-network/tslint.js
@@ -1,3 +1,0 @@
-module.exports = {
-  "extends": "../../../tslint.base",
-};

--- a/packages/@ionic/utils-network/tslint.json
+++ b/packages/@ionic/utils-network/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tslint.base.json"
+}

--- a/packages/@ionic/v1-toolkit/package.json
+++ b/packages/@ionic/v1-toolkit/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --config tslint.js --project tsconfig.json",
+    "lint": "tslint --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",

--- a/packages/@ionic/v1-toolkit/tslint.js
+++ b/packages/@ionic/v1-toolkit/tslint.js
@@ -1,3 +1,0 @@
-module.exports = {
-  "extends": "../../../tslint.base",
-};

--- a/packages/@ionic/v1-toolkit/tslint.json
+++ b/packages/@ionic/v1-toolkit/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tslint.base.json"
+}

--- a/packages/cli-scripts/package.json
+++ b/packages/cli-scripts/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --config tslint.js --project tsconfig.json",
+    "lint": "tslint --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",

--- a/packages/cli-scripts/tslint.js
+++ b/packages/cli-scripts/tslint.js
@@ -1,3 +1,0 @@
-module.exports = {
-  "extends": "../../tslint.base",
-};

--- a/packages/cli-scripts/tslint.json
+++ b/packages/cli-scripts/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tslint.base.json"
+}

--- a/packages/ionic/package.json
+++ b/packages/ionic/package.json
@@ -14,7 +14,7 @@
   "types": "./index.d.ts",
   "scripts": {
     "clean": "rimraf index.* bootstrap.* constants.* definitions.* guards.* lib commands",
-    "lint": "tslint --config tslint.js --project tsconfig.json",
+    "lint": "tslint --project tsconfig.json",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",

--- a/packages/ionic/tslint.js
+++ b/packages/ionic/tslint.js
@@ -1,3 +1,0 @@
-module.exports = {
-  "extends": "../../tslint.base",
-};

--- a/packages/ionic/tslint.json
+++ b/packages/ionic/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tslint.base.json"
+}

--- a/tslint.base.js
+++ b/tslint.base.js
@@ -1,8 +1,0 @@
-module.exports = {
-  "extends": "tslint-ionic-rules/strict",
-  "rules": {
-    "forin": false, // TODO
-    "no-empty-interface": false, // TODO
-    "strict-boolean-conditions": false,
-  },
-};

--- a/tslint.base.json
+++ b/tslint.base.json
@@ -1,0 +1,8 @@
+{
+  "extends": "tslint-ionic-rules/strict",
+  "rules": {
+    "forin": false,
+    "no-empty-interface": false,
+    "strict-boolean-conditions": false
+  }
+}


### PR DESCRIPTION
Visual Studio Code and WebStorm currently don't support the [undocumented][1]
tslint.js configuration format for TSLint.

[1]: https://palantir.github.io/tslint/usage/configuration/