### PR TITLE
docs(): update example command flags

### DIFF
--- a/packages/ionic/src/commands/serve.ts
+++ b/packages/ionic/src/commands/serve.ts
@@ -68,7 +68,7 @@ export class ServeCommand extends Command implements CommandPreRun {
       },
     ];
 
-    const exampleCommands = ['', '-c', '--local', '--lab'];
+    const exampleCommands = ['', '--local', '--lab'];
 
     let description = `
 Easily spin up a development server which launches in your browser. It watches for changes in your source files and automatically reloads with the updated build.

--- a/packages/ionic/src/lib/project/ionic-angular/serve.ts
+++ b/packages/ionic/src/lib/project/ionic-angular/serve.ts
@@ -78,7 +78,7 @@ export class IonicAngularServeRunner extends ServeRunner<IonicAngularServeOption
         ...APP_SCRIPTS_OPTIONS,
       ],
       exampleCommands: [
-        '-- --enableLint false',
+        '-c', '-- --enableLint false',
       ],
     };
   }


### PR DESCRIPTION
Removes `-c` from the global example commands to just ionic-angular apps.