### PR TITLE
fix(cli): Exclude options for command argument parsing (#3797)

### DIFF
--- a/packages/ionic/src/lib/executor.ts
+++ b/packages/ionic/src/lib/executor.ts
@@ -1,6 +1,5 @@
 import { AbstractExecutor, metadataOptionsToParseArgsOptions, parseArgs, stripOptions } from '@ionic/cli-framework';
 import chalk from 'chalk';
-import * as lodash from 'lodash';
 
 import { PROJECT_FILE } from '../constants';
 import { CommandInstanceInfo, CommandMetadata, CommandMetadataInput, CommandMetadataOption, ICommand, INamespace } from '../definitions';
@@ -33,7 +32,10 @@ export class Executor extends AbstractExecutor<ICommand, INamespace, CommandMeta
     }
 
     const cmd = location.obj;
-    const cmdargs = lodash.drop(argv, location.path.length - 1);
+    const path = location.path;
+    const subcommandName = path[path.length - 1][0];
+    const subcommandNameArgIdx = argv.findIndex(arg => arg === subcommandName);
+    const cmdargs = argv.slice(subcommandNameArgIdx + 1);
 
     await this.run(cmd, cmdargs, { location, env, executor: this });
   }


### PR DESCRIPTION
This fixes #3797 -- if you included Ionic CLI options *before* `cordova`, it would do the command positional parsing including those options since they aren't properly parsed out of the options sent to cordova even though they've already been consumed by Ionic.

This was handled by removing all arguments up to the final command in the command path -- the implication is that all arguments / options that follow the command in the path are for use by the command.