### PR TITLE
fix(): ionic doctor ViewportFixNotSet Ailment

### DIFF
--- a/packages/ionic/src/lib/doctor/ailments/index.ts
+++ b/packages/ionic/src/lib/doctor/ailments/index.ts
@@ -275,7 +275,7 @@ export class ViewportFitNotSet extends Ailment {
 
   async detected() {
     const indexHtml = await readFile(path.resolve(await this.project.getSourceDir(), 'index.html'), { encoding: 'utf8' });
-    const m = indexHtml.match(/\<meta.*viewport-fit=cover/);
+    const m = indexHtml.match(/\<meta([\s]*(name="viewport"){1})[\w\d\s\.\-,=]*(content="){1}[\w\d\s\.\-,=]*(viewport-fit=cover){1}[\w\d\s\.\-,="]+\/\>/);
     return !Boolean(m);
   }
 


### PR DESCRIPTION
Regex doesn't match on a multiline meta tag, an strict matcher is proposed to prevent match on other meta tags, only should match if a meta tag has name="viewport" property

done in test bench: https://regex101.com/r/yy1zT2/1