### PR TITLE
v1-toolkit now sends Access-Control-Allow-Origin: *

### DIFF
--- a/packages/@ionic/v1-toolkit/src/lib/serve.ts
+++ b/packages/@ionic/v1-toolkit/src/lib/serve.ts
@@ -128,6 +128,10 @@ async function createHttpServer(options: ServeOptions): Promise<ζexpress.Applic
   };
 
   app.get('/', serveIndex);
+  app.use('/', (req, res, next) => {
+    res.header('Access-Control-Allow-Origin', '*');
+    next();
+  });
   app.use('/', express.static(options.wwwDir));
 
   // Cordova


### PR DESCRIPTION
This is the change I'd make for #3856. We've tested this change and it works for the scenario described, as compared to ionic@4.10.2 where .tpl.html requests fail.