### PR TITLE
feat(serve): support --consolelogs for cordova-serve in angular projects

### DIFF
--- a/packages/ionic/src/definitions.ts
+++ b/packages/ionic/src/definitions.ts
@@ -566,6 +566,8 @@ export interface ServeOptions {
 }
 
 export interface AngularServeOptions extends ServeOptions {
+  consolelogs?: boolean;
+  consolelogsPort?: number;
   ssl?: boolean;
   configuration?: string;
   sourcemaps?: boolean;


### PR DESCRIPTION
Anything that triggers an `ionic-cordova-serve`, as defined in
`@ionic/angular-toolkit`, will pass through the --consolelogs and
--consolelogs-port flags, allowing you to print app console logs to
the terminal. Right now that is `ionic cordova run ios --livereload`
and `ionic serve --devapp`,

Addresses https://github.com/ionic-team/ionic-cli/issues/3169.

Depends on https://github.com/ionic-team/angular-toolkit/pull/100.