### PR TITLE
fix(capacitor): Send --npm-client param to capacitor init

### DIFF
--- a/packages/ionic/src/lib/integrations/capacitor/index.ts
+++ b/packages/ionic/src/lib/integrations/capacitor/index.ts
@@ -36,6 +36,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
       if (parsedArgs['web-dir']) {
         options.push('--web-dir', parsedArgs['web-dir']);
       }
+      options.push('--npm-client', this.e.config.get('npmClient'));
     }
 
     await this.installCapacitorCore();


### PR DESCRIPTION
On Capacitor beta 22, it added support for yarn package manager.
If it detects yarn installed and no `--npm-client` param is passed, it will prompt the user to choose a package manager, but that blocks the ionic cli. (see https://github.com/ionic-team/capacitor/issues/1453)

This PR will pass the `--npm-client` param to Capacitor CLI based on the configured `npmClient`