### PR TITLE
fix(react/vue): prevent usage of Cordova on vue and react projects

### DIFF
--- a/packages/ionic/src/commands/cordova/base.ts
+++ b/packages/ionic/src/commands/cordova/base.ts
@@ -107,7 +107,10 @@ export abstract class CordovaCommand extends Command {
       throw new FatalException('Cannot use Cordova outside a project directory.');
     }
     if (this.project.type === 'vue' || this.project.type === 'react') {
-      throw new FatalException(`Cordova is not supported for ${this.project.type} projects`);
+      throw new FatalException(
+        `Cordova is not supported for ${this.project.type} projects\n\n` +
+        `See ${strong(`https://ionicframework.com/docs/${this.project.type}/overview`)} for detailed information.\n`
+      );
     }
     const { loadConfigXml } = await import('../../lib/integrations/cordova/config');
 

--- a/packages/ionic/src/commands/cordova/base.ts
+++ b/packages/ionic/src/commands/cordova/base.ts
@@ -106,7 +106,9 @@ export abstract class CordovaCommand extends Command {
     if (!this.project) {
       throw new FatalException('Cannot use Cordova outside a project directory.');
     }
-
+    if (this.project.type === 'vue' || this.project.type === 'react') {
+      throw new FatalException(`Cordova is not supported for ${this.project.type} projects`);
+    }
     const { loadConfigXml } = await import('../../lib/integrations/cordova/config');
 
     await this.checkCordova(runinfo);

--- a/packages/ionic/src/lib/integrations/cordova/index.ts
+++ b/packages/ionic/src/lib/integrations/cordova/index.ts
@@ -23,7 +23,10 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
 
   async add(details: IntegrationAddDetails): Promise<void> {
     if (this.e.project.type === 'vue' || this.e.project.type === 'react') {
-      throw new FatalException(`Cordova is not supported for ${this.e.project.type} projects`);
+      throw new FatalException(
+        `Cordova is not supported for ${this.e.project.type} projects\n\n` +
+        `See ${strong(`https://ionicframework.com/docs/${this.e.project.type}/overview`)} for detailed information.\n`
+      );
     }
     const handlers: IntegrationAddHandlers = {
       conflictHandler: async (f, stats) => {

--- a/packages/ionic/src/lib/integrations/cordova/index.ts
+++ b/packages/ionic/src/lib/integrations/cordova/index.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 
 import { BaseIntegration, IntegrationConfig } from '../';
 import { InfoItem, IntegrationAddDetails, IntegrationAddHandlers, IntegrationName, ProjectIntegration, ProjectPersonalizationDetails } from '../../../definitions';
+import { FatalException } from '../../../lib/errors';
 import { ancillary, input, strong } from '../../color';
 
 const debug = Debug('ionic:lib:integrations:cordova');
@@ -21,6 +22,9 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
   }
 
   async add(details: IntegrationAddDetails): Promise<void> {
+    if (this.e.project.type === 'vue' || this.e.project.type === 'angular') {
+      throw new FatalException(`Cordova is not supported for ${this.e.project.type} projects`);
+    }
     const handlers: IntegrationAddHandlers = {
       conflictHandler: async (f, stats) => {
         const isDirectory = stats.isDirectory();

--- a/packages/ionic/src/lib/integrations/cordova/index.ts
+++ b/packages/ionic/src/lib/integrations/cordova/index.ts
@@ -22,7 +22,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
   }
 
   async add(details: IntegrationAddDetails): Promise<void> {
-    if (this.e.project.type === 'vue' || this.e.project.type === 'angular') {
+    if (this.e.project.type === 'vue' || this.e.project.type === 'react') {
       throw new FatalException(`Cordova is not supported for ${this.e.project.type} projects`);
     }
     const handlers: IntegrationAddHandlers = {


### PR DESCRIPTION
Prevents users from adding Cordova to vue and react projects.

Prevents it for `ionic integrations enable cordova` and ` ionic cordova platform add`, not sure if more commands need it too.