### PR TITLE
chore: update node engines to >=8.9.4

### DIFF
--- a/packages/@ionic/cli-framework/package.json
+++ b/packages/@ionic/cli-framework/package.json
@@ -7,7 +7,7 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "engines": {
-    "node": ">=6.4.0"
+    "node": ">=8.9.4"
   },
   "scripts": {
     "clean": "rimraf index.* definitions.* errors.* guards.* lib utils",

--- a/packages/ionic/package.json
+++ b/packages/ionic/package.json
@@ -8,7 +8,7 @@
     "ionic": "./bin/ionic"
   },
   "engines": {
-    "node": ">=6.4.0"
+    "node": ">=8.9.4"
   },
   "main": "./index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
As node 8.9.4 or greater is required, update the engines in the package.json files that had an older value. 