### PR TITLE
docs(changelog): angular-toolkit upgrade clarification

### DIFF
--- a/packages/ionic/CHANGELOG.md
+++ b/packages/ionic/CHANGELOG.md
@@ -133,11 +133,18 @@ Install the [`cordova-res`](https://github.com/ionic-team/cordova-res) and [`nat
 npm i -g cordova-res native-run
 ```
 
-For Angular projects, make sure you have the latest `@ionic/angular-toolkit` installed.
+For Angular 8 projects, make sure you have the latest `@ionic/angular-toolkit` installed.
 
 ```
 npm i @ionic/angular-toolkit@latest
 ```
+
+For Angular 7 projects, make sure you have the [latest 1.x](https://www.npmjs.com/package/@ionic/angular-toolkit?activeTab=versions) `@ionic/angular-toolkit` installed.
+
+```
+npm i @ionic/angular-toolkit@1.5.1
+```
+
 
 ### Bug Fixes
 

--- a/packages/ionic/CHANGELOG.md
+++ b/packages/ionic/CHANGELOG.md
@@ -142,7 +142,7 @@ npm i @ionic/angular-toolkit@latest
 For Angular 7 projects, make sure you have the [latest 1.x](https://www.npmjs.com/package/@ionic/angular-toolkit?activeTab=versions) `@ionic/angular-toolkit` installed.
 
 ```
-npm i @ionic/angular-toolkit@1.5.1
+npm i @ionic/angular-toolkit@1
 ```
 
 


### PR DESCRIPTION
When upgrading Angular 7 projects use `npm i @ionic/angular-toolkit@1.5.1` otherwise it installs v2.0+ which is for Angular 8 and results in errors like this:

```[INFO] Hardware device(s) found for android. Using --device.
> ng.cmd run app:ionic-cordova-build --platform=android
Schema validation failed with the following errors:
  Data path ".builders['cordova-build']" should have required property 'class'.
[ERROR] An error occurred while running subprocess ng.
```

Based on the [solution presented here](https://github.com/ionic-team/angular-toolkit/issues/166#issuecomment-510460934).