### PR TITLE
docs(changelog): clarify exact min node ver req

### DIFF
--- a/packages/ionic/CHANGELOG.md
+++ b/packages/ionic/CHANGELOG.md
@@ -125,7 +125,7 @@ At a glance, this is what was changed or added in this major release of the Ioni
 
 #### :lollipop: Upgrading from CLI 4
 
-Make sure you have NodeJS 8+ installed. We recommend [the latest LTS version](https://nodejs.org/).
+Make sure you have NodeJS v8.9.4+ installed. We recommend [the latest LTS version](https://nodejs.org/).
 
 Install the [`cordova-res`](https://github.com/ionic-team/cordova-res) and [`native-run`](https://github.com/ionic-team/native-run) utilities.
 


### PR DESCRIPTION
It's noted explicitly in the breaking changes section but was left vague further up.