### PR TITLE
Additional #4156 work

### DIFF
--- a/packages/ionic/src/commands/cordova/run.ts
+++ b/packages/ionic/src/commands/cordova/run.ts
@@ -334,14 +334,19 @@ Just like with ${input('ionic cordova build')}, you can pass additional options 
       }
     }
 
+    const buildOpts: IShellRunOptions = { };
+    // ignore very verbose compiler output unless --verbose (still pipe stderr)
+    if (!options['verbose']) {
+      buildOpts.stdio = ['ignore', 'ignore', 'pipe'];
+    }
+
     if (options['native-run']) {
       const [ platform ] = inputs;
       const packagePath = await getPackagePath(conf.getProjectInfo().name, platform, { emulator: !options['device'], release: !!options['release'] });
-
-      await this.runCordova(filterArgumentsForCordova({ ...metadata, name: 'build' }, options), { stdio: 'inherit' });
+      await this.runCordova(filterArgumentsForCordova({ ...metadata, name: 'build' }, options), buildOpts);
       await this.runNativeRun(createNativeRunArgs({ packagePath, platform }, { ...options, connect: false }));
     } else {
-      await this.runCordova(filterArgumentsForCordova(metadata, options), { stdio: 'inherit' });
+      await this.runCordova(filterArgumentsForCordova(metadata, options), buildOpts);
     }
   }
 

--- a/packages/ionic/src/commands/cordova/run.ts
+++ b/packages/ionic/src/commands/cordova/run.ts
@@ -331,17 +331,14 @@ Just like with ${input('ionic cordova build')}, you can pass additional options 
       }
     }
 
-    const buildOpts: IShellRunOptions = { };
-    // ignore very verbose compiler output on stdout unless --verbose
-    buildOpts.stdio = options['verbose'] ? 'inherit' : ['pipe', 'ignore', 'pipe'];
-
     if (options['native-run']) {
       const [ platform ] = inputs;
       const packagePath = await getPackagePath(conf.getProjectInfo().name, platform, { emulator: !options['device'], release: !!options['release'] });
-      await this.runCordova(filterArgumentsForCordova({ ...metadata, name: 'build' }, options), buildOpts);
+
+      await this.runCordova(filterArgumentsForCordova({ ...metadata, name: 'build' }, options), { stdio: 'inherit' });
       await this.runNativeRun(createNativeRunArgs({ packagePath, platform }, { ...options, connect: false }));
     } else {
-      await this.runCordova(filterArgumentsForCordova(metadata, options), buildOpts);
+      await this.runCordova(filterArgumentsForCordova(metadata, options), { stdio: 'inherit' });
     }
   }
 

--- a/packages/ionic/src/commands/cordova/run.ts
+++ b/packages/ionic/src/commands/cordova/run.ts
@@ -291,22 +291,21 @@ Just like with ${input('ionic cordova build')}, you can pass additional options 
     await conf.save();
 
     const cordovalogws = createPrefixedWriteStream(this.env.log, weak(`[cordova]`));
+    const buildOpts: IShellRunOptions = { stream: cordovalogws };
+    // ignore very verbose compiler output unless --verbose (still pipe stderr)
+    if (!options['verbose']) {
+      buildOpts.stdio = ['ignore', 'ignore', 'pipe'];
+    }
 
     if (options['native-run']) {
       const [ platform ] = inputs;
       const packagePath = await getPackagePath(conf.getProjectInfo().name, platform, { emulator: !options['device'], release: !!options['release'] });
       const forwardedPorts = details ? runner.getUsedPorts(runnerOpts, details) : [];
 
-      const buildOpts: IShellRunOptions = { stream: cordovalogws };
-      // ignore very verbose compiler output unless --verbose (still pipe stderr)
-      if (!options['verbose']) {
-        buildOpts.stdio = ['ignore', 'ignore', 'pipe'];
-      }
-
       await this.runCordova(filterArgumentsForCordova({ ...metadata, name: 'build' }, options), buildOpts);
       await this.runNativeRun(createNativeRunArgs({ packagePath, platform, forwardedPorts }, options));
     } else {
-      await this.runCordova(filterArgumentsForCordova(metadata, options), { stream: cordovalogws });
+      await this.runCordova(filterArgumentsForCordova(metadata, options), buildOpts);
       await sleepForever();
     }
   }

--- a/packages/ionic/src/commands/cordova/run.ts
+++ b/packages/ionic/src/commands/cordova/run.ts
@@ -292,10 +292,8 @@ Just like with ${input('ionic cordova build')}, you can pass additional options 
 
     const cordovalogws = createPrefixedWriteStream(this.env.log, weak(`[cordova]`));
     const buildOpts: IShellRunOptions = { stream: cordovalogws };
-    // ignore very verbose compiler output unless --verbose (still pipe stderr)
-    if (!options['verbose']) {
-      buildOpts.stdio = ['ignore', 'ignore', 'pipe'];
-    }
+    // ignore very verbose compiler output on stdout unless --verbose
+    buildOpts.stdio = options['verbose'] ? 'inherit' : ['pipe', 'ignore', 'pipe'];
 
     if (options['native-run']) {
       const [ platform ] = inputs;
@@ -334,10 +332,8 @@ Just like with ${input('ionic cordova build')}, you can pass additional options 
     }
 
     const buildOpts: IShellRunOptions = { };
-    // ignore very verbose compiler output unless --verbose (still pipe stderr)
-    if (!options['verbose']) {
-      buildOpts.stdio = ['ignore', 'ignore', 'pipe'];
-    }
+    // ignore very verbose compiler output on stdout unless --verbose
+    buildOpts.stdio = options['verbose'] ? 'inherit' : ['pipe', 'ignore', 'pipe'];
 
     if (options['native-run']) {
       const [ platform ] = inputs;


### PR DESCRIPTION
Some additional updates related to #4156 to ensure that stdio is properly set for 'runServeDeploy()' and 'runBuildDeploy()' so that `ionic cordova run` functions as expected in all code paths, specifically with various combinations of `--livereload`, `--verbose`, and `--no-native-run`.

fixes https://github.com/ionic-team/ionic-cli/issues/4165