### PR TITLE
feat(serve): add `--public-host` option

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -32,7 +32,7 @@ export class RunCommand extends CapacitorCommand implements CommandPreRun {
         type: Boolean,
         default: true,
       },
-      ...COMMON_SERVE_COMMAND_OPTIONS.filter(o => !['livereload'].includes(o.name)),
+      ...COMMON_SERVE_COMMAND_OPTIONS.filter(o => !['livereload'].includes(o.name)).map(o => ({ ...o, hint: weak('(--livereload)') })),
       {
         name: 'livereload',
         summary: 'Spin up dev server to live-reload www files',

--- a/packages/@ionic/cli/src/commands/cordova/run.ts
+++ b/packages/@ionic/cli/src/commands/cordova/run.ts
@@ -68,7 +68,7 @@ export class RunCommand extends CordovaCommand implements CommandPreRun {
       },
       ...COMMON_BUILD_COMMAND_OPTIONS.filter(o => !['engine', 'platform'].includes(o.name)),
       // Serve Options
-      ...COMMON_SERVE_COMMAND_OPTIONS.filter(o => !['livereload'].includes(o.name)),
+      ...COMMON_SERVE_COMMAND_OPTIONS.filter(o => !['livereload'].includes(o.name)).map(o => ({ ...o, hint: weak('(--livereload)') })),
       {
         name: 'livereload',
         summary: 'Spin up dev server to live-reload www files',

--- a/packages/@ionic/cli/src/definitions.ts
+++ b/packages/@ionic/cli/src/definitions.ts
@@ -597,6 +597,7 @@ export interface ServeOptions {
   // Command Options
   host: string;
   port: number;
+  publicHost?: string;
   livereload: boolean;
   proxy: boolean;
   lab: boolean;

--- a/packages/@ionic/cli/src/lib/__tests__/serve.ts
+++ b/packages/@ionic/cli/src/lib/__tests__/serve.ts
@@ -20,6 +20,7 @@ describe('@ionic/cli', () => {
 
         const defaults = {
           '--': [],
+          publicHost: undefined,
           host: 'localhost',
           browser: undefined,
           browserOption: undefined,
@@ -56,7 +57,7 @@ describe('@ionic/cli', () => {
 
         it('should respect --external flag', () => {
           const runner = new MyServeRunner({});
-          const result = runner.createOptionsFromCommandLine([], { _: [], external: true });
+          const result = runner.createOptionsFromCommandLine([], { _: [], host: 'localhost', external: true });
           expect(result).toEqual({ ...defaults, host: '0.0.0.0' });
         });
 

--- a/packages/@ionic/cli/src/lib/project/angular/__tests__/serve.ts
+++ b/packages/@ionic/cli/src/lib/project/angular/__tests__/serve.ts
@@ -11,6 +11,7 @@ describe('@ionic/cli', () => {
 
         const defaults = {
           '--': [],
+          publicHost: undefined,
           host: 'localhost',
           browser: undefined,
           browserOption: undefined,
@@ -49,7 +50,7 @@ describe('@ionic/cli', () => {
 
         it('should respect --external flag', () => {
           const runner = new AngularServeRunner({} as any);
-          const result = runner.createOptionsFromCommandLine([], { _: [], external: true });
+          const result = runner.createOptionsFromCommandLine([], { _: [], host: 'localhost', external: true });
           expect(result).toEqual({ ...defaults, host: '0.0.0.0' });
         });
 

--- a/packages/@ionic/cli/src/lib/project/angular/serve.ts
+++ b/packages/@ionic/cli/src/lib/project/angular/serve.ts
@@ -227,6 +227,8 @@ export class AngularServeCLI extends ServeCLI<AngularServeOptions> {
 
       args.consolelogs = options.consolelogs ? true : undefined;
       args['consolelogs-port'] = options.consolelogsPort ? String(options.consolelogsPort) : undefined;
+    } else {
+      args['public-host'] = options.publicHost; // TODO: @ionic/angular-toolkit would need to support --public-host
     }
 
     if (this.resolvedProgram !== this.program) {

--- a/packages/@ionic/cli/src/lib/project/ionic-angular/__tests__/serve.ts
+++ b/packages/@ionic/cli/src/lib/project/ionic-angular/__tests__/serve.ts
@@ -10,6 +10,7 @@ describe('@ionic/cli', () => {
 
         const defaults = {
           '--': [],
+          publicHost: undefined,
           host: 'localhost',
           browser: undefined,
           browserOption: undefined,
@@ -51,7 +52,7 @@ describe('@ionic/cli', () => {
 
         it('should respect --external flag', () => {
           const runner = new IonicAngularServeRunner({} as any);
-          const result = runner.createOptionsFromCommandLine([], { _: [], external: true });
+          const result = runner.createOptionsFromCommandLine([], { _: [], host: 'localhost', external: true });
           expect(result).toEqual({ ...defaults, host: '0.0.0.0' });
         });
 

--- a/packages/@ionic/cli/src/lib/project/ionic1/__tests__/serve.ts
+++ b/packages/@ionic/cli/src/lib/project/ionic1/__tests__/serve.ts
@@ -10,6 +10,7 @@ describe('@ionic/cli', () => {
 
         const defaults = {
           '--': [],
+          publicHost: undefined,
           host: 'localhost',
           browser: undefined,
           browserOption: undefined,
@@ -50,7 +51,7 @@ describe('@ionic/cli', () => {
 
         it('should respect --external flag', () => {
           const runner = new Ionic1ServeRunner({} as any);
-          const result = runner.createOptionsFromCommandLine([], { _: [], external: true });
+          const result = runner.createOptionsFromCommandLine([], { _: [], host: 'localhost', external: true });
           expect(result).toEqual({ ...defaults, host: '0.0.0.0' });
         });
 


### PR DESCRIPTION
This adds a `--public-host` option to `ionic serve`. It differs slighty
from the Angular CLI's `--public-host` option in that the Ionic CLI will
open the provided host, instead of localhost.

Please test: `npm i -g @ionic/cli@6.2.0-testing.5`

resolves https://github.com/ionic-team/ionic-cli/issues/3558