### PR TITLE
fix(angular): always provide the project name fallback

### DIFF
--- a/packages/@ionic/cli/src/lib/project/angular/__tests__/generate.ts
+++ b/packages/@ionic/cli/src/lib/project/angular/__tests__/generate.ts
@@ -11,7 +11,7 @@ describe('@ionic/cli', () => {
 
         const defaults = {
           name: undefined,
-          project: undefined,
+          project: 'app',
           type: undefined,
         };
 

--- a/packages/@ionic/cli/src/lib/project/angular/__tests__/generate.ts
+++ b/packages/@ionic/cli/src/lib/project/angular/__tests__/generate.ts
@@ -1,0 +1,42 @@
+import { CommandLineOptions } from '../../../../definitions';
+import { AngularGenerateRunner } from '../generate';
+
+describe('@ionic/cli', () => {
+
+  describe('lib/project/angular/generate', () => {
+
+    describe('AngularGenerateRunner', () => {
+
+      describe('createOptionsFromCommandLine', () => {
+
+        const defaults = {
+          name: undefined,
+          project: undefined,
+          type: undefined,
+        };
+
+        it('should provide defaults with no inputs or options', () => {
+          const runner = new AngularGenerateRunner({} as any);
+          const result = runner.createOptionsFromCommandLine([], {} as CommandLineOptions);
+          expect(result).toEqual(defaults);
+        });
+
+        it('should provide options from inputs', () => {
+          const runner = new AngularGenerateRunner({} as any);
+          const result = runner.createOptionsFromCommandLine(['service', 'FancyBar'], { _: [] });
+          expect(result).toEqual({ ...defaults, name: 'FancyBar', type: 'service' });
+        });
+
+        it('should respect --project', () => {
+          const runner = new AngularGenerateRunner({} as any);
+          const result = runner.createOptionsFromCommandLine([], { _: [], project: 'otherProject' });
+          expect(result).toEqual({ ...defaults, project: 'otherProject' });
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/packages/@ionic/cli/src/lib/project/angular/__tests__/serve.ts
+++ b/packages/@ionic/cli/src/lib/project/angular/__tests__/serve.ts
@@ -24,7 +24,7 @@ describe('@ionic/cli', () => {
           open: false,
           port: 8100,
           proxy: true,
-          project: undefined,
+          project: 'app',
           prod: undefined,
           platform: undefined,
           verbose: false,
@@ -62,8 +62,8 @@ describe('@ionic/cli', () => {
 
         it('should respect --project and --configuration flags', () => {
           const runner = new AngularServeRunner({} as any);
-          const result = runner.createOptionsFromCommandLine([], { _: [], project: 'app', configuration: 'production' });
-          expect(result).toEqual({ ...defaults, project: 'app', configuration: 'production' });
+          const result = runner.createOptionsFromCommandLine([], { _: [], project: 'otherProject', configuration: 'production' });
+          expect(result).toEqual({ ...defaults, project: 'otherProject', configuration: 'production' });
         });
 
         it('should pass on separated args', () => {

--- a/packages/@ionic/cli/src/lib/project/angular/build.ts
+++ b/packages/@ionic/cli/src/lib/project/angular/build.ts
@@ -80,6 +80,7 @@ ${input('ionic build')} uses the Angular CLI. Use ${input('ng build --help')} to
     const baseOptions = super.createBaseOptionsFromCommandLine(inputs, options);
     const prod = options['prod'] ? Boolean(options['prod']) : undefined;
     const configuration = options['configuration'] ? String(options['configuration']) : (prod ? 'production' : undefined);
+    const project = options['project'] ? String(options['project']) : 'app';
     const sourcemaps = typeof options['source-map'] === 'boolean' ? Boolean(options['source-map']) : undefined;
     const cordovaAssets = typeof options['cordova-assets'] === 'boolean' ? Boolean(options['cordova-assets']) : undefined;
     const watch = typeof options['watch'] === 'boolean' ? Boolean(options['watch']) : undefined;
@@ -87,6 +88,7 @@ ${input('ionic build')} uses the Angular CLI. Use ${input('ng build --help')} to
     return {
       ...baseOptions,
       configuration,
+      project,
       sourcemaps,
       cordovaAssets,
       watch,
@@ -161,8 +163,7 @@ export class AngularBuildCLI extends BuildCLI<AngularBuildOptions> {
 
   protected buildArchitectCommand(options: AngularBuildOptions): string[] {
     const cmd = options.engine === 'cordova' ? 'ionic-cordova-build' : 'build';
-    const project = options.project ? options.project : 'app';
 
-    return ['run', `${project}:${cmd}${options.configuration ? `:${options.configuration}` : ''}`];
+    return ['run', `${options.project}:${cmd}${options.configuration ? `:${options.configuration}` : ''}`];
   }
 }

--- a/packages/@ionic/cli/src/lib/project/angular/generate.ts
+++ b/packages/@ionic/cli/src/lib/project/angular/generate.ts
@@ -100,12 +100,13 @@ To test a generator before file modifications are made, use the ${input('--dry-r
 
   createOptionsFromCommandLine(inputs: CommandLineInputs, options: CommandLineOptions): AngularGenerateOptions {
     const baseOptions = super.createOptionsFromCommandLine(inputs, options);
+    const project = options['project'] ? String(options['project']) : 'app';
 
     // TODO: this is a little gross, is there a better way to pass in all the
     // options that the command got?
     return {
       ...lodash.omit(options, '_', '--', ...GLOBAL_OPTIONS.map(opt => opt.name)),
-      project: options['project'],
+      project,
       ...baseOptions,
     };
   }

--- a/packages/@ionic/cli/src/lib/project/angular/serve.ts
+++ b/packages/@ionic/cli/src/lib/project/angular/serve.ts
@@ -94,6 +94,7 @@ The dev server can use HTTPS via the ${input('--ssl')} option ${chalk.bold.red('
     const prod = options['prod'] ? Boolean(options['prod']) : undefined;
     const ssl = options['ssl'] ? Boolean(options['ssl']) : undefined;
     const configuration = options['configuration'] ? String(options['configuration']) : (prod ? 'production' : undefined);
+    const project = options['project'] ? String(options['project']) : 'app';
     const sourcemaps = typeof options['source-map'] === 'boolean' ? Boolean(options['source-map']) : undefined;
     const consolelogs = typeof options['consolelogs'] === 'boolean' ? Boolean(options['consolelogs']) : undefined;
     const consolelogsPort = consolelogs ? str2num(options['consolelogs-port'], DEFAULT_CONSOLE_LOGS_PORT) : undefined;
@@ -104,6 +105,7 @@ The dev server can use HTTPS via the ${input('--ssl')} option ${chalk.bold.red('
       consolelogsPort,
       ssl,
       configuration,
+      project,
       sourcemaps,
     };
   }
@@ -250,8 +252,7 @@ export class AngularServeCLI extends ServeCLI<AngularServeOptions> {
 
   protected buildArchitectCommand(options: AngularServeOptions): string[] {
     const cmd = options.engine === 'cordova' ? 'ionic-cordova-serve' : 'serve';
-    const project = options.project ? options.project : 'app';
 
-    return ['run', `${project}:${cmd}${options.configuration ? `:${options.configuration}` : ''}`];
+    return ['run', `${options.project}:${cmd}${options.configuration ? `:${options.configuration}` : ''}`];
   }
 }


### PR DESCRIPTION
This MR ports some changes from #4311, which is no longer required after the `--multi-app` feature was introduced.

With this MR, the Angular specific Runner commands will consistently provide all defaults passed to the Angular CLI in the `createOptionsFromCommandLine` method.


Closes #4192