### PR TITLE
Added the --no-open option

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/build.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/build.ts
@@ -24,6 +24,12 @@ export class BuildCommand extends CapacitorCommand implements CommandPreRun {
         type: Boolean,
         default: true,
       },
+      {
+        name: 'open',
+        summary: 'Do not invoke Capacitor open',
+        type: Boolean,
+        default: true,
+      },
     ];
 
     const footnotes: Footnote[] = [
@@ -121,7 +127,9 @@ To configure your native project, see the common configuration docs[^capacitor-n
     this.env.log.info(this.getContinueMessage(platform));
     this.env.log.nl();
 
-    await this.runCapacitor(['open', platform]);
+    if (options['open']) {
+      await this.runCapacitor(['open', platform]);
+    }
   }
 
   protected getContinueMessage(platform: string): string {

--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -30,6 +30,12 @@ export class RunCommand extends CapacitorCommand implements CommandPreRun {
         type: Boolean,
         default: true,
       },
+      {
+        name: 'open',
+        summary: 'Do not invoke Capacitor open',
+        type: Boolean,
+        default: true,
+      },
       ...COMMON_SERVE_COMMAND_OPTIONS.filter(o => !['livereload'].includes(o.name)).map(o => ({ ...o, hint: weak('(--livereload)') })),
       {
         name: 'livereload',
@@ -157,7 +163,9 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
     this.env.log.info(this.getContinueMessage(platform));
     this.env.log.nl();
 
-    await this.runCapacitor(['open', platform]);
+    if (options['open']) {
+      await this.runCapacitor(['open', platform]);
+    }
 
     if (options['livereload']) {
       this.env.log.nl();


### PR DESCRIPTION
Added the option `--no-open` Do not invoke Capacitor open, to the ionic capacitor `build` and `run` commands.

This option will make it easier to use ionic capacitor from the command line, especially when you what to use the `--livereload` option.

Currently, if you what to use live reload from the CLI. You can not use the `ionic capacitor run <platform> --livereload` command, because it will always start the corresponding IDE. So you have to write custom scripts that will update the `capacitor.config.json` file with the correct information needed for live reload to work. This pull request can make this use case simpler.

