### PR TITLE
Added note to explain how to use for serving to emulators and to lan/devices

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -17,8 +17,8 @@ export class RunCommand extends CapacitorCommand implements CommandPreRun {
     const exampleCommands = [
       '',
       'android',
-      'android -l',
-      'ios --livereload',
+      'android -l --external',
+      'ios --livereload --external',
       'ios --livereload-url=http://localhost:8100',
     ].sort();
 
@@ -88,6 +88,8 @@ ${input('ionic capacitor run')} will do the following:
 - Perform ${input('ionic build')} (or run the dev server from ${input('ionic serve')} with the ${input('--livereload')} option)
 - Copy web assets into the specified native platform
 - Open the IDE for your native project (Xcode for iOS, Android Studio for Android)
+
+When using the ${input('--livereload')} option and need to serve to your LAN, a device, or an emulator, use the ${input('--external')} option also. Otherwise, the web view tries to access ${input('localhost')}.
 
 Once the web assets and configuration are copied into your native project, the app can run on devices and emulators/simulators using the native IDE. Unfortunately, programmatically building and launching the native project is not yet supported.
 


### PR DESCRIPTION
Adds context to the help/docs to explain how to use when serving to emulators and devices with live reload server. By default the docs didn't explain that the live reload server opens at localhost and this doesn't work when using emulators/devices. 

For example, android can only reach the host machine through LAN IP or host loopback address 10.0.2.2. Localhost points to the device itself and the web view displays an error (unreachable host).

Future work planned to streamline how this works e.g. for Android using the 10.0.2.2 default host address: (https://github.com/ionic-team/ionic-cli/issues/4419)