### PR TITLE
fix(package): Fixed name of the package deploy name

### DIFF
--- a/packages/@ionic/cli/src/commands/package/deploy.ts
+++ b/packages/@ionic/cli/src/commands/package/deploy.ts
@@ -46,7 +46,7 @@ export class DeployCommand extends Command {
     const dashUrl = this.env.config.getDashUrl();
 
     return {
-      name: 'build',
+      name: 'deploy',
       type: 'project',
       summary: 'Deploys a binary to a destination, such as an app store using Appflow',
       description: `


### PR DESCRIPTION
Fixed the name of the command for `ionic package deploy`