### PR TITLE
chore: mark Appflow and Enterprise commands as paid

### DIFF
--- a/packages/@ionic/cli/src/commands/deploy/add.ts
+++ b/packages/@ionic/cli/src/commands/deploy/add.ts
@@ -13,6 +13,7 @@ export class AddCommand extends DeployConfCommand {
     return {
       name: 'add',
       type: 'project',
+      groups: [MetadataGroup.PAID],
       summary: 'Adds Appflow Deploy to the project',
       description: `
 This command adds the Appflow Deploy plugin (${input('cordova-plugin-ionic')}) for both Capacitor and Cordova projects.

--- a/packages/@ionic/cli/src/commands/deploy/build.ts
+++ b/packages/@ionic/cli/src/commands/deploy/build.ts
@@ -36,6 +36,7 @@ export class BuildCommand extends Command {
     return {
       name: 'build',
       type: 'project',
+      groups: [MetadataGroup.PAID],
       summary: 'Create a deploy build on Appflow',
       description: `
 This command creates a deploy build on Ionic Appflow. While the build is running, it prints the remote build log to the terminal.

--- a/packages/@ionic/cli/src/commands/deploy/configure.ts
+++ b/packages/@ionic/cli/src/commands/deploy/configure.ts
@@ -11,7 +11,7 @@ export class ConfigureCommand extends DeployConfCommand {
     return {
       name: 'configure',
       type: 'project',
-      groups: [MetadataGroup.HIDDEN],
+      groups: [MetadataGroup.PAID],
       summary: 'Overrides Appflow Deploy configuration',
       description: `
 This command overrides configuration for the Appflow Deploy plugin (${input('cordova-plugin-ionic')}) in Capacitor projects.

--- a/packages/@ionic/cli/src/commands/deploy/manifest.ts
+++ b/packages/@ionic/cli/src/commands/deploy/manifest.ts
@@ -24,7 +24,7 @@ export class DeployManifestCommand extends DeployCoreCommand {
       name: 'manifest',
       type: 'project',
       summary: 'Generates a manifest file for the deploy service from a built app directory',
-      groups: [MetadataGroup.HIDDEN],
+      groups: [MetadataGroup.PAID],
     };
   }
 

--- a/packages/@ionic/cli/src/commands/enterprise/register.ts
+++ b/packages/@ionic/cli/src/commands/enterprise/register.ts
@@ -1,3 +1,5 @@
+import { MetadataGroup } from '@ionic/cli-framework';
+
 import { CommandInstanceInfo, CommandLineInputs, CommandLineOptions, CommandMetadata } from '../../definitions';
 import { input } from '../../lib/color';
 import { Command } from '../../lib/command';
@@ -9,6 +11,7 @@ export class RegisterCommand extends Command {
     return {
       name: 'register',
       type: 'project',
+      groups: [MetadataGroup.PAID],
       summary: 'Register your Product Key with this app',
       options: [
         {

--- a/packages/@ionic/cli/src/commands/git/remote.ts
+++ b/packages/@ionic/cli/src/commands/git/remote.ts
@@ -1,3 +1,5 @@
+import { MetadataGroup } from '@ionic/cli-framework';
+
 import { CommandLineInputs, CommandLineOptions, CommandMetadata } from '../../definitions';
 import { input, strong } from '../../lib/color';
 import { Command } from '../../lib/command';
@@ -10,6 +12,7 @@ export class GitRemoteCommand extends Command {
     return {
       name: 'remote',
       type: 'project',
+      groups: [MetadataGroup.PAID],
       summary: 'Adds/updates the Ionic Appflow git remote to your local Ionic app',
       description: `
 This command is used by ${input('ionic link')} when Ionic Appflow is used as the git host.

--- a/packages/@ionic/cli/src/commands/link.ts
+++ b/packages/@ionic/cli/src/commands/link.ts
@@ -33,6 +33,7 @@ export class LinkCommand extends Command implements CommandPreRun {
     return {
       name: 'link',
       type: 'project',
+      groups: [MetadataGroup.PAID],
       summary: 'Connect local apps to Ionic',
       description: `
 Link apps on Ionic Appflow to local Ionic projects with this command.

--- a/packages/@ionic/cli/src/commands/package/build.ts
+++ b/packages/@ionic/cli/src/commands/package/build.ts
@@ -57,6 +57,7 @@ export class BuildCommand extends Command {
     return {
       name: 'build',
       type: 'project',
+      groups: [MetadataGroup.PAID],
       summary: 'Create a package build on Appflow',
       description: `
 This command creates a package build on Ionic Appflow. While the build is running, it prints the remote build log to the terminal. If the build is successful, it downloads the created app package file in the current directory.

--- a/packages/@ionic/cli/src/commands/package/deploy.ts
+++ b/packages/@ionic/cli/src/commands/package/deploy.ts
@@ -2,6 +2,7 @@ import {
   CommandLineInputs,
   CommandLineOptions,
   LOGGER_LEVELS,
+  MetadataGroup,
   combine,
   validators,
 } from '@ionic/cli-framework';
@@ -48,6 +49,7 @@ export class DeployCommand extends Command {
     return {
       name: 'deploy',
       type: 'project',
+      groups: [MetadataGroup.PAID],
       summary: 'Deploys a binary to a destination, such as an app store using Appflow',
       description: `
 This command deploys a binary to a destination using Ionic Appflow. While running, the remote log is printed to the terminal.


### PR DESCRIPTION
After internal Slack discussions, let's get these 2 commands added to the Ionic CLI docs.