### PR TITLE
chore: update to TypeScript 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lerna": "^3.13.3",
     "tslint": "^5.9.1",
     "tslint-ionic-rules": "0.0.21",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "chokidar-cli": "^2.0.0",
     "husky": "^4.2.0",
     "lerna": "^3.13.3",
-    "tslint": "^5.9.1",
-    "tslint-ionic-rules": "0.0.21",
     "typescript": "~4.0.2"
   },
   "husky": {

--- a/packages/@ionic/cli-framework-output/package.json
+++ b/packages/@ionic/cli-framework-output/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -30,7 +30,7 @@
     "slice-ansi": "^4.0.0",
     "string-width": "^4.1.0",
     "strip-ansi": "^6.0.0",
-    "tslib": "2.0.1",
+    "tslib": "^2.0.1",
     "wrap-ansi": "^7.0.0"
   },
   "devDependencies": {
@@ -46,7 +46,6 @@
     "jest-cli": "^26.0.1",
     "lint-staged": "^10.0.2",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/cli-framework-output/package.json
+++ b/packages/@ionic/cli-framework-output/package.json
@@ -30,7 +30,7 @@
     "slice-ansi": "^4.0.0",
     "string-width": "^4.1.0",
     "strip-ansi": "^6.0.0",
-    "tslib": "1.11.2",
+    "tslib": "2.0.1",
     "wrap-ansi": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@ionic/cli-framework-output/package.json
+++ b/packages/@ionic/cli-framework-output/package.json
@@ -47,6 +47,6 @@
     "lint-staged": "^10.0.2",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/cli-framework-output/tslint.json
+++ b/packages/@ionic/cli-framework-output/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/cli-framework-prompts/package.json
+++ b/packages/@ionic/cli-framework-prompts/package.json
@@ -27,7 +27,7 @@
     "@ionic/utils-terminal": "2.2.0",
     "debug": "^4.0.0",
     "inquirer": "^7.0.0",
-    "tslib": "1.11.2"
+    "tslib": "2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",

--- a/packages/@ionic/cli-framework-prompts/package.json
+++ b/packages/@ionic/cli-framework-prompts/package.json
@@ -39,6 +39,6 @@
     "lint-staged": "^10.0.2",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/cli-framework-prompts/package.json
+++ b/packages/@ionic/cli-framework-prompts/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -27,7 +27,7 @@
     "@ionic/utils-terminal": "2.2.0",
     "debug": "^4.0.0",
     "inquirer": "^7.0.0",
-    "tslib": "2.0.1"
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",
@@ -38,7 +38,6 @@
     "jest-cli": "^26.0.1",
     "lint-staged": "^10.0.2",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/cli-framework-prompts/tslint.json
+++ b/packages/@ionic/cli-framework-prompts/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/cli-framework/package.json
+++ b/packages/@ionic/cli-framework/package.json
@@ -32,7 +32,7 @@
     "lodash": "^4.17.5",
     "minimist": "^1.2.0",
     "rimraf": "^3.0.0",
-    "tslib": "1.11.2",
+    "tslib": "2.0.1",
     "untildify": "^4.0.0",
     "write-file-atomic": "^3.0.0"
   },

--- a/packages/@ionic/cli-framework/package.json
+++ b/packages/@ionic/cli-framework/package.json
@@ -48,6 +48,6 @@
     "lint-staged": "^10.0.2",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/cli-framework/package.json
+++ b/packages/@ionic/cli-framework/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "clean": "rimraf index.* definitions.* errors.* guards.* lib utils",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -32,7 +32,7 @@
     "lodash": "^4.17.5",
     "minimist": "^1.2.0",
     "rimraf": "^3.0.0",
-    "tslib": "2.0.1",
+    "tslib": "^2.0.1",
     "untildify": "^4.0.0",
     "write-file-atomic": "^3.0.0"
   },
@@ -47,7 +47,6 @@
     "jest-cli": "^26.0.1",
     "lint-staged": "^10.0.2",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/cli-framework/src/definitions.ts
+++ b/packages/@ionic/cli-framework/src/definitions.ts
@@ -56,8 +56,6 @@ export interface CommandMetadataOption extends Metadata {
   };
 }
 
-export type HydratedCommandMetadataOption<O extends CommandMetadataOption> = Readonly<Required<O>>;
-
 export { ParseArgsOptions };
 
 export interface HydratedParseArgsOptions extends ParseArgsOptions {

--- a/packages/@ionic/cli-framework/src/lib/options.ts
+++ b/packages/@ionic/cli-framework/src/lib/options.ts
@@ -1,7 +1,7 @@
 import * as lodash from 'lodash';
 import * as minimist from 'minimist';
 
-import { CommandLineOptions, CommandMetadataOption, HydratedCommandMetadataOption, HydratedParseArgsOptions, ParsedArg } from '../definitions';
+import { CommandLineOptions, CommandMetadataOption, HydratedParseArgsOptions, ParsedArg } from '../definitions';
 
 import { Colors, DEFAULT_COLORS } from './colors';
 
@@ -56,12 +56,12 @@ export function separateArgv(pargv: readonly string[]): [string[], string[]] {
 /**
  * Takes a Minimist command option and normalizes its values.
  */
-export function hydrateCommandMetadataOption<O extends CommandMetadataOption>(option: O): HydratedCommandMetadataOption<O> {
+export function hydrateCommandMetadataOption<O extends CommandMetadataOption>(option: O): O {
   const type = option.type ? option.type : String;
 
   return lodash.assign({}, option, {
     type,
-    default: typeof option.default !== 'undefined' ? option.default : null, // tslint:disable-line:no-null-keyword
+    default: typeof option.default !== 'undefined' ? option.default : null,
     aliases: Array.isArray(option.aliases) ? option.aliases : [],
   });
 }
@@ -116,8 +116,13 @@ export function metadataOptionsToParseArgsOptions(commandOptions: readonly Comma
       options.boolean.push(opt.name);
     }
 
-    options.default[opt.name] = opt.default;
-    options.alias[opt.name] = opt.aliases;
+    if (typeof opt.default !== 'undefined') {
+      options.default[opt.name] = opt.default;
+    }
+
+    if (typeof opt.aliases !== 'undefined') {
+      options.alias[opt.name] = opt.aliases;
+    }
   }
 
   return options;

--- a/packages/@ionic/cli-framework/tslint.json
+++ b/packages/@ionic/cli-framework/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/cli/package.json
+++ b/packages/@ionic/cli/package.json
@@ -88,6 +88,6 @@
     "source-map": "^0.7.0",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/cli/package.json
+++ b/packages/@ionic/cli/package.json
@@ -65,7 +65,7 @@
     "superagent": "^5.2.1",
     "superagent-proxy": "^2.0.0",
     "tar": "^6.0.1",
-    "tslib": "1.11.2"
+    "tslib": "2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",

--- a/packages/@ionic/cli/package.json
+++ b/packages/@ionic/cli/package.json
@@ -14,7 +14,7 @@
   "types": "./index.d.ts",
   "scripts": {
     "clean": "rimraf index.* bootstrap.* constants.* definitions.* guards.* lib commands",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -65,7 +65,7 @@
     "superagent": "^5.2.1",
     "superagent-proxy": "^2.0.0",
     "tar": "^6.0.1",
-    "tslib": "2.0.1"
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",
@@ -87,7 +87,6 @@
     "rimraf": "^3.0.0",
     "source-map": "^0.7.0",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/cli/src/commands/config/base.ts
+++ b/packages/@ionic/cli/src/commands/config/base.ts
@@ -59,7 +59,7 @@ export abstract class BaseConfigCommand extends Command {
     try {
       const serialized = JSON.stringify(v);
 
-      if (typeof serialized === 'undefined') { // tslint:disable-line:strict-type-predicates
+      if (typeof serialized === 'undefined') {
         throw new FatalException(`Cannot serialize value: ${strong(v)}`);
       }
 

--- a/packages/@ionic/cli/src/commands/link.ts
+++ b/packages/@ionic/cli/src/commands/link.ts
@@ -476,7 +476,7 @@ If you are having issues linking, please get in touch with our Support[^support-
       name: strong('Nevermind'),
       id: CHOICE_NEVERMIND,
       value: CHOICE_NEVERMIND,
-      org: null, // tslint:disable-line
+      org: null,
     };
 
     const linkedApp = await this.env.prompt({

--- a/packages/@ionic/cli/src/commands/ssh/generate.ts
+++ b/packages/@ionic/cli/src/commands/ssh/generate.ts
@@ -69,7 +69,7 @@ export class SSHGenerateCommand extends SSHBaseCommand implements CommandPreRun 
     const pubkeyPath = `${keyPath}.pub`;
 
     if (!(await pathExists(keyPathDir))) {
-      await mkdirp(keyPathDir, 0o700 as any); // tslint:disable-line
+      await mkdirp(keyPathDir, 0o700 as any);
       this.env.log.msg(`Created ${strong(prettyPath(keyPathDir))} directory for you.`);
     }
 

--- a/packages/@ionic/cli/src/commands/ssl/generate.ts
+++ b/packages/@ionic/cli/src/commands/ssl/generate.ts
@@ -178,7 +178,7 @@ The default directory for ${input('--key-path')} and ${input('--cert-path')} is 
 
   private async ensureDirectory(p: string) {
     if (!(await pathExists(p))) {
-      await mkdirp(p, 0o700 as any); // tslint:disable-line
+      await mkdirp(p, 0o700 as any);
       this.env.log.msg(`Created ${strong(prettyPath(p))} directory for you.`);
     }
   }

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -108,10 +108,10 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
     const [
       [ capacitorCorePkg, capacitorCorePkgPath ],
       capacitorCLIVersion,
-    ] = await (Promise.all([
+    ] = await (Promise.all<[PackageJson | undefined, string | undefined], string | undefined>([
       this.e.project.getPackageJson('@capacitor/core'),
       this.getCapacitorCLIVersion(),
-    ]) as Promise<[[PackageJson | undefined, string], string | undefined]>); // TODO: https://github.com/microsoft/TypeScript/issues/33752
+    ]));
 
     const info: InfoItem[] = [
       {

--- a/packages/@ionic/cli/src/lib/integrations/cordova/__tests__/project.ts
+++ b/packages/@ionic/cli/src/lib/integrations/cordova/__tests__/project.ts
@@ -1,4 +1,5 @@
-import * as fsSpy from '@ionic/utils-fs';
+import * as fsExtraSpy from 'fs-extra';
+import * as fsSafeSpy from '@ionic/utils-fs/dist/safe';
 import * as project from '../project';
 
 describe('@ionic/cli', () => {
@@ -8,21 +9,21 @@ describe('@ionic/cli', () => {
     describe('getPlatforms', () => {
 
       it('should filter out files and hidden files/folders', async () => {
-        const files = [['.DS_Store', false], ['.dir', true], ['android', true], ['ios', true], ['platforms.json', false]];
-        spyOn(fsSpy, 'readdirSafe').and.callFake(async () => files.map(([f]) => f));
-        spyOn(fsSpy, 'statSafe').and.callFake(async (p) => ({
+        const files: [string, boolean][] = [['.DS_Store', false], ['.dir', true], ['android', true], ['ios', true], ['platforms.json', false]];
+        jest.spyOn(fsSafeSpy, 'readdir').mockImplementation(async () => files.map(([f]) => f));
+        jest.spyOn(fsSafeSpy, 'stat').mockImplementation(async (p) => ({
           isDirectory: () => {
             const file = files.find(([f]) => p.endsWith(f));
             return typeof file !== 'undefined' && file[1];
           },
-        }));
+        } as any));
 
         const platforms = await project.getPlatforms('/path/to/proj');
         expect(platforms).toEqual(['android', 'ios']);
       });
 
       it('should not error if directory empty', async () => {
-        spyOn(fsSpy, 'readdirSafe').and.callFake(async () => []);
+        jest.spyOn(fsSafeSpy, 'readdir').mockImplementation(async () => []);
         const platforms = await project.getPlatforms('/path/to/proj');
         expect(platforms).toEqual([]);
       });
@@ -32,14 +33,14 @@ describe('@ionic/cli', () => {
     describe('getAndroidBuildOutputJson', () => {
 
       it('should throw for fs error', () => {
-        spyOn(fsSpy, 'readJson').and.callFake(async () => { throw new Error('error') });
+        jest.spyOn(fsExtraSpy, 'readJson').mockImplementation(async () => { throw new Error('error') });
 
         const p = project.getAndroidBuildOutputJson('/path/to/output.json');
         expect(p).rejects.toThrowError('Could not parse build output file');
       });
 
       it('should throw for unrecognized format', () => {
-        spyOn(fsSpy, 'readJson').and.callFake(async () => ({ foo: 'bar' }));
+        jest.spyOn(fsExtraSpy, 'readJson').mockImplementation(async () => ({ foo: 'bar' }));
 
         const p = project.getAndroidBuildOutputJson('/path/to/output.json');
         expect(p).rejects.toThrowError('Could not parse build output file');
@@ -55,7 +56,7 @@ describe('@ionic/cli', () => {
           },
         ];
 
-        spyOn(fsSpy, 'readJson').and.callFake(async () => file);
+        jest.spyOn(fsExtraSpy, 'readJson').mockImplementation(async () => file);
 
         const p = project.getAndroidBuildOutputJson('/path/to/output.json');
         expect(p).resolves.toEqual(file);
@@ -73,7 +74,7 @@ describe('@ionic/cli', () => {
           ],
         };
 
-        spyOn(fsSpy, 'readJson').and.callFake(async () => file);
+        jest.spyOn(fsExtraSpy, 'readJson').mockImplementation(async () => file);
 
         const p = project.getAndroidBuildOutputJson('/path/to/output.json');
         expect(p).resolves.toEqual(file);
@@ -93,7 +94,7 @@ describe('@ionic/cli', () => {
           },
         ];
 
-        spyOn(fsSpy, 'readJson').and.callFake(async () => file);
+        jest.spyOn(fsExtraSpy, 'readJson').mockImplementation(async () => file);
 
         const p = project.getAndroidPackageFilePath('/path/to/proj', { release: false });
         expect(p).resolves.toEqual('platforms/android/app/build/outputs/apk/debug/foo-debug.apk');
@@ -111,7 +112,7 @@ describe('@ionic/cli', () => {
           ],
         };
 
-        spyOn(fsSpy, 'readJson').and.callFake(async () => file);
+        jest.spyOn(fsExtraSpy, 'readJson').mockImplementation(async () => file);
 
         const p = project.getAndroidPackageFilePath('/path/to/proj', { release: false });
         expect(p).resolves.toEqual('platforms/android/app/build/outputs/apk/debug/bar-debug.apk');

--- a/packages/@ionic/cli/src/lib/integrations/cordova/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/cordova/index.ts
@@ -149,7 +149,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
       iosDeploy,
       iosSim,
       androidSdkToolsVersion,
-    ] = await (Promise.all([
+    ] = await (Promise.all<string | undefined, string, string, string | undefined, string | undefined, string | undefined, string | undefined>([
       this.getCordovaVersion(),
       this.getCordovaPlatformVersions(),
       this.getCordovaPluginVersions(),
@@ -157,7 +157,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
       this.getIOSDeployVersion(),
       this.getIOSSimVersion(),
       getAndroidSdkToolsVersion(),
-    ]) as Promise<[string | undefined, string, string, string | undefined, string | undefined, string | undefined, string | undefined]>); // TODO: https://github.com/microsoft/TypeScript/issues/33752
+    ]));
 
     const info: InfoItem[] = [
       { group: 'cordova', name: 'Cordova CLI', key: 'cordova_version', value: cordovaVersion || 'not installed' },

--- a/packages/@ionic/cli/src/lib/native-run.ts
+++ b/packages/@ionic/cli/src/lib/native-run.ts
@@ -93,7 +93,7 @@ export async function runNativeRun({ config, log, shell }: RunNativeRunDeps, arg
   // should also connect the Ionic CLI with the running `native-run` process.
   // This will exit the Ionic CLI when `native-run` exits.
   if (connect) {
-    processExit(0); // tslint:disable-line:no-floating-promises
+    processExit(0);
   }
 }
 

--- a/packages/@ionic/cli/src/lib/project/index.ts
+++ b/packages/@ionic/cli/src/lib/project/index.ts
@@ -275,13 +275,13 @@ export class ProjectDetails {
       if (isProjectConfig(config)) {
         const r = await this.determineSingleApp(config);
         errors.push(...r.errors);
-        return { configPath, errors, ...r };
+        return { ...r, configPath, errors };
       }
 
       if (isMultiProjectConfig(config)) {
         const r = await this.determineMultiApp(config);
         errors.push(...r.errors);
-        return { configPath, errors, ...r };
+        return { ...r, configPath, errors };
       }
 
       throw new ProjectDetailsError('Unknown project file structure', 'ERR_INVALID_PROJECT_FILE');
@@ -596,7 +596,6 @@ export abstract class Project implements IProject {
   }
 
   // Empty to avoid sub-classes having to implement
-  // tslint:disable-next-line:no-empty
   async setPrimaryTheme(_themeColor: string): Promise<void> { }
 
   async writeThemeColor(variablesPath: string, themeColor: string): Promise<void> {

--- a/packages/@ionic/cli/src/lib/project/ionic1/index.ts
+++ b/packages/@ionic/cli/src/lib/project/ionic1/index.ts
@@ -42,10 +42,10 @@ export class Ionic1Project extends Project {
     const [
       ionic1Version,
       [ v1ToolkitPkg ],
-    ] = await (Promise.all([
+    ] = await (Promise.all<string | undefined, [PackageJson | undefined, string | undefined]>([
       this.getFrameworkVersion(),
       this.getPackageJson('@ionic/v1-toolkit'),
-    ]) as Promise<[string | undefined, [PackageJson | undefined, string]]>); // TODO: https://github.com/microsoft/TypeScript/issues/33752
+    ]));
 
     return [
       ...(await super.getInfo()),

--- a/packages/@ionic/cli/src/lib/serve.ts
+++ b/packages/@ionic/cli/src/lib/serve.ts
@@ -508,7 +508,7 @@ export abstract class ServeCLI<T extends ServeCLIOptions> extends EventEmitter {
       };
 
       const closeHandler = (code: number | null) => {
-        if (code !== null) { // tslint:disable-line:no-null-keyword
+        if (code !== null) {
           debug('received unexpected close for %s (code: %d)', this.resolvedProgram, code);
 
           this.e.log.nl();
@@ -517,7 +517,7 @@ export abstract class ServeCLI<T extends ServeCLIOptions> extends EventEmitter {
             'The Ionic CLI will exit. Please check any output above for error details.'
           );
 
-          processExit(1); // tslint:disable-line:no-floating-promises
+          processExit(1);
         }
       };
 

--- a/packages/@ionic/cli/src/lib/utils/color.ts
+++ b/packages/@ionic/cli/src/lib/utils/color.ts
@@ -49,7 +49,6 @@ function hslToRGB({ h, s, l }: HSL): RGB {
     };
   }
 
-  // tslint:disable-next-line:no-shadowed-variable
   const hue2rgb = (p: number, q: number, t: number) => {
     if (t < 0) { t += 1; }
     if (t > 1) { t -= 1; }

--- a/packages/@ionic/cli/tslint.json
+++ b/packages/@ionic/cli/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/discover/package.json
+++ b/packages/@ionic/discover/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "debug": "^4.0.0",
     "netmask": "^1.0.6",
-    "tslib": "1.11.2",
+    "tslib": "2.0.1",
     "ws": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@ionic/discover/package.json
+++ b/packages/@ionic/discover/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -30,7 +30,7 @@
   "dependencies": {
     "debug": "^4.0.0",
     "netmask": "^1.0.6",
-    "tslib": "2.0.1",
+    "tslib": "^2.0.1",
     "ws": "^7.0.0"
   },
   "devDependencies": {
@@ -44,7 +44,6 @@
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/discover/package.json
+++ b/packages/@ionic/discover/package.json
@@ -45,6 +45,6 @@
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/discover/tslint.json
+++ b/packages/@ionic/discover/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/lab/package.json
+++ b/packages/@ionic/lab/package.json
@@ -55,6 +55,6 @@
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/lab/package.json
+++ b/packages/@ionic/lab/package.json
@@ -31,7 +31,7 @@
     "clean": "npm run clean.tsc",
     "clean.tsc": "rimraf dist",
     "clean.stencil": "rimraf www",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run build.tsc && npm run build.stencil",
     "build.stencil": "npm run clean.stencil && stencil build",
     "build.tsc": "npm run clean.tsc && tsc",
@@ -45,7 +45,7 @@
     "@ionic/utils-fs": "3.1.4",
     "chalk": "^4.0.0",
     "express": "^4.16.2",
-    "tslib": "2.0.1"
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@ionic-internal/ionic-ds": "^2.1.0",
@@ -54,7 +54,6 @@
     "@types/node": "~10.17.13",
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/lab/package.json
+++ b/packages/@ionic/lab/package.json
@@ -45,7 +45,7 @@
     "@ionic/utils-fs": "3.1.4",
     "chalk": "^4.0.0",
     "express": "^4.16.2",
-    "tslib": "1.11.2"
+    "tslib": "2.0.1"
   },
   "devDependencies": {
     "@ionic-internal/ionic-ds": "^2.1.0",

--- a/packages/@ionic/lab/tslint.json
+++ b/packages/@ionic/lab/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/utils-array/package.json
+++ b/packages/@ionic/utils-array/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "debug": "^4.0.0",
-    "tslib": "1.11.2"
+    "tslib": "2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",

--- a/packages/@ionic/utils-array/package.json
+++ b/packages/@ionic/utils-array/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "debug": "^4.0.0",
-    "tslib": "2.0.1"
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",
@@ -43,7 +43,6 @@
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-array/package.json
+++ b/packages/@ionic/utils-array/package.json
@@ -44,6 +44,6 @@
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-array/tslint.json
+++ b/packages/@ionic/utils-array/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/utils-fs/package.json
+++ b/packages/@ionic/utils-fs/package.json
@@ -46,6 +46,6 @@
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-fs/package.json
+++ b/packages/@ionic/utils-fs/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "debug": "^4.0.0",
     "fs-extra": "^9.0.0",
-    "tslib": "1.11.2"
+    "tslib": "2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",

--- a/packages/@ionic/utils-fs/package.json
+++ b/packages/@ionic/utils-fs/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -33,7 +33,7 @@
   "dependencies": {
     "debug": "^4.0.0",
     "fs-extra": "^9.0.0",
-    "tslib": "2.0.1"
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",
@@ -45,7 +45,6 @@
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-fs/src/index.ts
+++ b/packages/@ionic/utils-fs/src/index.ts
@@ -198,7 +198,7 @@ export async function getFileChecksum(filePath: string): Promise<string> {
  * @return Promise<[true checksum, cached checksum or undefined if cache file missing]>
  */
 export async function getFileChecksums(p: string): Promise<[string, string | undefined]> {
-  return Promise.all([
+  return Promise.all<string, string | undefined>([
     getFileChecksum(p),
     (async () => {
       try {
@@ -210,7 +210,7 @@ export async function getFileChecksums(p: string): Promise<[string, string | und
         }
       }
     })(),
-  ]) as Promise<[string, string | undefined]>; // TODO: https://github.com/microsoft/TypeScript/issues/33752
+  ]);
 }
 
 /**
@@ -260,10 +260,10 @@ export async function pathExecutable(filePath: string): Promise<boolean> {
 }
 
 export async function isExecutableFile(filePath: string): Promise<boolean> {
-  const [ stats, executable ] = await (Promise.all([
+  const [ stats, executable ] = await (Promise.all<fs.Stats | undefined, boolean>([
     safe.stat(filePath),
     pathExecutable(filePath),
-  ]) as Promise<[fs.Stats, boolean]>); // TODO: https://github.com/microsoft/TypeScript/issues/33752
+  ]));
 
   return !!stats && (stats.isFile() || stats.isSymbolicLink()) && executable;
 }
@@ -363,7 +363,7 @@ export class Walker extends stream.Readable {
     const { pathFilter } = this.options;
 
     if (!p) {
-      this.push(null); // tslint:disable-line:no-null-keyword
+      this.push(null);
       return;
     }
 

--- a/packages/@ionic/utils-fs/tslint.json
+++ b/packages/@ionic/utils-fs/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/utils-network/package.json
+++ b/packages/@ionic/utils-network/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "debug": "^4.0.0",
-    "tslib": "1.11.2"
+    "tslib": "2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",

--- a/packages/@ionic/utils-network/package.json
+++ b/packages/@ionic/utils-network/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "debug": "^4.0.0",
-    "tslib": "2.0.1"
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",
@@ -43,7 +43,6 @@
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-network/package.json
+++ b/packages/@ionic/utils-network/package.json
@@ -44,6 +44,6 @@
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-network/tslint.json
+++ b/packages/@ionic/utils-network/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/utils-object/package.json
+++ b/packages/@ionic/utils-object/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "debug": "^4.0.0",
-    "tslib": "1.11.2"
+    "tslib": "2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",

--- a/packages/@ionic/utils-object/package.json
+++ b/packages/@ionic/utils-object/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "debug": "^4.0.0",
-    "tslib": "2.0.1"
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",
@@ -43,7 +43,6 @@
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-object/package.json
+++ b/packages/@ionic/utils-object/package.json
@@ -44,6 +44,6 @@
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-object/tslint.json
+++ b/packages/@ionic/utils-object/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/utils-process/package.json
+++ b/packages/@ionic/utils-process/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -36,7 +36,7 @@
     "debug": "^4.0.0",
     "signal-exit": "^3.0.3",
     "tree-kill": "^1.2.2",
-    "tslib": "2.0.1"
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",
@@ -48,7 +48,6 @@
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-process/package.json
+++ b/packages/@ionic/utils-process/package.json
@@ -49,6 +49,6 @@
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-process/package.json
+++ b/packages/@ionic/utils-process/package.json
@@ -36,7 +36,7 @@
     "debug": "^4.0.0",
     "signal-exit": "^3.0.3",
     "tree-kill": "^1.2.2",
-    "tslib": "1.11.2"
+    "tslib": "2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",

--- a/packages/@ionic/utils-process/tslint.json
+++ b/packages/@ionic/utils-process/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/utils-stream/package.json
+++ b/packages/@ionic/utils-stream/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "debug": "^4.0.0",
-    "tslib": "1.11.2"
+    "tslib": "2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",

--- a/packages/@ionic/utils-stream/package.json
+++ b/packages/@ionic/utils-stream/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "debug": "^4.0.0",
-    "tslib": "2.0.1"
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",
@@ -44,7 +44,6 @@
     "rimraf": "^3.0.0",
     "stream-combiner2": "^1.1.1",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-stream/package.json
+++ b/packages/@ionic/utils-stream/package.json
@@ -45,6 +45,6 @@
     "stream-combiner2": "^1.1.1",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-stream/src/index.ts
+++ b/packages/@ionic/utils-stream/src/index.ts
@@ -67,7 +67,7 @@ export class ReadableStreamBuffer extends Readable {
     this._stopped = true;
 
     if (this._size === 0) {
-      this.push(null); // tslint:disable-line:no-null-keyword
+      this.push(null);
     }
   }
 
@@ -84,7 +84,7 @@ export class ReadableStreamBuffer extends Readable {
     }
 
     if (this._size === 0 && this._stopped) {
-      this.push(null); // tslint:disable-line:no-null-keyword
+      this.push(null);
     }
 
     if (!done) {

--- a/packages/@ionic/utils-stream/tslint.json
+++ b/packages/@ionic/utils-stream/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/utils-subprocess/package.json
+++ b/packages/@ionic/utils-subprocess/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -38,7 +38,7 @@
     "@ionic/utils-terminal": "2.2.0",
     "cross-spawn": "^7.0.0",
     "debug": "^4.0.0",
-    "tslib": "2.0.1"
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.0",
@@ -50,7 +50,6 @@
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-subprocess/package.json
+++ b/packages/@ionic/utils-subprocess/package.json
@@ -38,7 +38,7 @@
     "@ionic/utils-terminal": "2.2.0",
     "cross-spawn": "^7.0.0",
     "debug": "^4.0.0",
-    "tslib": "1.11.2"
+    "tslib": "2.0.1"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.0",

--- a/packages/@ionic/utils-subprocess/package.json
+++ b/packages/@ionic/utils-subprocess/package.json
@@ -51,6 +51,6 @@
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-subprocess/tslint.json
+++ b/packages/@ionic/utils-subprocess/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/utils-terminal/package.json
+++ b/packages/@ionic/utils-terminal/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "debug": "^4.0.0",
-    "tslib": "1.11.2"
+    "tslib": "2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",

--- a/packages/@ionic/utils-terminal/package.json
+++ b/packages/@ionic/utils-terminal/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "echo 'no tests yet'",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "debug": "^4.0.0",
-    "tslib": "2.0.1"
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",
@@ -43,7 +43,6 @@
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-terminal/package.json
+++ b/packages/@ionic/utils-terminal/package.json
@@ -44,6 +44,6 @@
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/utils-terminal/tslint.json
+++ b/packages/@ionic/utils-terminal/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/@ionic/v1-toolkit/package.json
+++ b/packages/@ionic/v1-toolkit/package.json
@@ -45,7 +45,7 @@
     "gulp": "^4.0.2",
     "http-proxy-middleware": "^0.20.0",
     "tiny-lr": "^1.1.0",
-    "tslib": "1.11.2",
+    "tslib": "2.0.1",
     "ws": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@ionic/v1-toolkit/package.json
+++ b/packages/@ionic/v1-toolkit/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -45,7 +45,7 @@
     "gulp": "^4.0.2",
     "http-proxy-middleware": "^0.20.0",
     "tiny-lr": "^1.1.0",
-    "tslib": "2.0.1",
+    "tslib": "^2.0.1",
     "ws": "^7.0.0"
   },
   "devDependencies": {
@@ -62,7 +62,6 @@
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/v1-toolkit/package.json
+++ b/packages/@ionic/v1-toolkit/package.json
@@ -63,6 +63,6 @@
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/@ionic/v1-toolkit/tslint.json
+++ b/packages/@ionic/v1-toolkit/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../../tslint.base.json"
-}

--- a/packages/cli-scripts/package.json
+++ b/packages/cli-scripts/package.json
@@ -23,7 +23,7 @@
     "chalk": "^4.0.0",
     "escape-string-regexp": "^4.0.0",
     "strip-ansi": "^6.0.0",
-    "tslib": "1.11.2"
+    "tslib": "2.0.1"
   },
   "devDependencies": {
     "@types/ansi-styles": "^3.2.0",

--- a/packages/cli-scripts/package.json
+++ b/packages/cli-scripts/package.json
@@ -35,6 +35,6 @@
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
     "tslint": "^5.9.1",
-    "typescript": "~3.8.2"
+    "typescript": "~4.0.2"
   }
 }

--- a/packages/cli-scripts/package.json
+++ b/packages/cli-scripts/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "true",
     "build": "npm run clean && tsc",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "jest --maxWorkers=4",
@@ -23,7 +23,7 @@
     "chalk": "^4.0.0",
     "escape-string-regexp": "^4.0.0",
     "strip-ansi": "^6.0.0",
-    "tslib": "2.0.1"
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@types/ansi-styles": "^3.2.0",
@@ -34,7 +34,6 @@
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",
     "ts-jest": "~26.3.0",
-    "tslint": "^5.9.1",
     "typescript": "~4.0.2"
   }
 }

--- a/packages/cli-scripts/tslint.json
+++ b/packages/cli-scripts/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../tslint.base.json"
-}

--- a/tslint.base.json
+++ b/tslint.base.json
@@ -1,8 +1,0 @@
-{
-  "extends": "tslint-ionic-rules/strict",
-  "rules": {
-    "forin": false,
-    "no-empty-interface": false,
-    "strict-boolean-conditions": false
-  }
-}


### PR DESCRIPTION
This removes tslint because it appears to no longer be compatible with the syntax parser.