### PR TITLE
Update example commands to use "Signing Certificate"

### DIFF
--- a/packages/@ionic/cli/src/commands/package/build.ts
+++ b/packages/@ionic/cli/src/commands/package/build.ts
@@ -83,13 +83,13 @@ This can be used only together with build type ${input('release')} for Android a
       ],
       exampleCommands: [
         'android debug',
-        'ios development --security-profile="iOS Security Profile Name"',
+        'ios development --security-profile="iOS Signing Certificate Name"',
         'android debug --environment="My Custom Environment Name"',
         'android debug --native-config="My Custom Native Config Name"',
         'android debug --commit=2345cd3305a1cf94de34e93b73a932f25baac77c',
-        'ios development --security-profile="iOS Security Profile Name" --target-platform="iOS - Xcode 9"',
-        'ios development --security-profile="iOS Security Profile Name" --build-file-name=my_custom_file_name.ipa',
-        'ios app-store --security-profile="iOS Security Profile Name" --destination="Apple App Store Destination"',
+        'ios development --security-profile="iOS Signing Certificate Name" --target-platform="iOS - Xcode 9"',
+        'ios development --security-profile="iOS Signing Certificate Name" --build-file-name=my_custom_file_name.ipa',
+        'ios app-store --security-profile="iOS Signing Certificate Name" --destination="Apple App Store Destination"',
       ],
       inputs: [
         {


### PR DESCRIPTION
References to the term "security profile" in Appflow and the associated documentation are changing to "signing certificate". This change update the references to this in the example commands without changing the name of the actual flag in hopes to make this language change more intuitive for the user following the documentation.

https://ionic-cloud.atlassian.net/browse/CT-269
https://github.com/ionic-team/ionic-dashboard/pull/150
https://github.com/ionic-team/ionic-docs/pull/1675