### PR TITLE
fix(cli): fix stdin to unblock react-scripts>3.4.0

### DIFF
--- a/packages/@ionic/cli/src/lib/serve.ts
+++ b/packages/@ionic/cli/src/lib/serve.ts
@@ -493,7 +493,7 @@ export abstract class ServeCLI<T extends ServeCLIOptions> extends EventEmitter {
   protected async spawn(options: T): Promise<void> {
     const args = await this.buildArgs(options);
     const env = await this.buildEnvVars(options);
-    const p = await this.e.shell.spawn(this.resolvedProgram, args, { stdio: 'pipe', cwd: this.e.project.directory, env: createProcessEnv(env) });
+    const p = await this.e.shell.spawn(this.resolvedProgram, args, { stdio: ['inherit', 'pipe', 'pipe'], cwd: this.e.project.directory, env: createProcessEnv(env) });
 
     return new Promise<void>((resolve, reject) => {
       const errorHandler = (err: NodeJS.ErrnoException) => {


### PR DESCRIPTION
Should solve: https://github.com/ionic-team/ionic-cli/issues/4392

In `react-scripts 3.4.1`, a fragment of code for handling script exit was added:
https://github.com/facebook/create-react-app/blob/v3.4.1/packages/react-scripts/scripts/start.js#L168-L175

```js
if (isInteractive || process.env.CI !== 'true') {
  // Gracefully exit when stdin ends
  process.stdin.on('end', function() {
    devServer.close();
    process.exit();
  });
  process.stdin.resume();
}
```

Here, `react-scripts` tries to listen to the `stdin`, and it has no issues when you start `react-scripts` directly in Git Bash or CMD on Windows.
However, with `ionic serve`, the `@ionic/cli` will spawn `react-scripts` in a child process with its `stdin` exposed as a `pipe` (`{ stdio: 'pipe', ...`), which is not connected to any other input stream [like `stdout` and `stderr` do](https://github.com/ppoffice/ionic-cli/blob/e150aebf2628f52d42096266b71e95dede5ef872/packages/%40ionic/cli/src/lib/serve.ts#L537-L538).
And this causes the problem on Windows.
I'm not sure about the root cause, but changing `stdio: 'pipe'` to `stdio: ['inherit', 'pipe', 'pipe']` (let `react-scritps` inherit the `stdio` on `@ionic/cli`) seems to resolve the issue for me.

Please try this fix yourself and see if your issue is resolved.

Steps to reproduce the issue mentioned in https://github.com/ionic-team/ionic-cli/issues/4392:

1. Install Ionic CLI on Windows. I'm using `@ionic/cli@6.10.1`;
2. Create a new Ionic project with `ionic start myApp tabs --type=react`;
3. Upgrade `react-scripts` to `3.4.1` or above in your new Ionic project;
4. Run `ionic serve` from your project root and see if it hangs at `Files successfully emitted, waiting for typecheck results...`

Steps to fix the issue using this patch:

1. Go to wherever you installed `@ionic/cli` and open `lib\serve.js`;
2. Apply the fix in this PR;
3. Restart `ionic serve` to see if the issue is resolved.