### PR TITLE
feat(capacitor): Capacitor 3 support

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/add.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/add.ts
@@ -1,10 +1,7 @@
 import { validators } from '@ionic/cli-framework';
-import * as semver from 'semver';
 
 import { CommandInstanceInfo, CommandLineInputs, CommandLineOptions, CommandMetadata, CommandPreRun } from '../../definitions';
 import { input } from '../../lib/color';
-import { FatalException } from '../../lib/errors';
-import { pkgManagerArgs } from '../../lib/utils/npm';
 
 import { CapacitorCommand } from './base';
 
@@ -22,7 +19,7 @@ ${input('ionic capacitor add')} will do the following:
       inputs: [
         {
           name: 'platform',
-          summary: `The platform to add (e.g. ${['android', 'ios', 'electron'].map(v => input(v)).join(', ')})`,
+          summary: `The platform to add (e.g. ${['android', 'ios'].map(v => input(v)).join(', ')})`,
           validators: [validators.required],
         },
       ],
@@ -37,7 +34,7 @@ ${input('ionic capacitor add')} will do the following:
         type: 'list',
         name: 'platform',
         message: 'What platform would you like to add?',
-        choices: ['android', 'ios', 'electron'],
+        choices: ['android', 'ios'],
       });
 
       inputs[0] = platform.trim();
@@ -46,20 +43,7 @@ ${input('ionic capacitor add')} will do the following:
 
   async run(inputs: CommandLineInputs, options: CommandLineOptions): Promise<void> {
     const [ platform ] = inputs;
-    const version = await this.getCapacitorVersion();
 
-    const installedPlatforms = await this.getInstalledPlatforms();
-
-    if (installedPlatforms.includes(platform)) {
-      throw new FatalException(`The ${input(platform)} platform is already installed!`);
-    }
-
-    if (semver.gte(version, '3.0.0-alpha.1')) {
-      const [ manager, ...managerArgs ] = await pkgManagerArgs(this.env.config.get('npmClient'), { command: 'install', pkg: `@capacitor/${platform}`, saveDev: true });
-      await this.env.shell.run(manager, managerArgs, { cwd: this.integration.root });
-    }
-
-    const args = ['add', platform];
-    await this.runCapacitor(args);
+    await this.installPlatform(platform);
   }
 }

--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -273,7 +273,7 @@ export abstract class CapacitorCommand extends Command {
     }
 
     if (semver.gte(version, '3.0.0-alpha.1')) {
-      const [ manager, ...managerArgs ] = await pkgManagerArgs(this.env.config.get('npmClient'), { command: 'install', pkg: `@capacitor/${platform}`, saveDev: true });
+      const [ manager, ...managerArgs ] = await pkgManagerArgs(this.env.config.get('npmClient'), { command: 'install', pkg: `@capacitor/${platform}@next`, saveDev: true });
       await this.env.shell.run(manager, managerArgs, { cwd: this.integration.root });
     }
 

--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -1,6 +1,7 @@
 import { pathExists } from '@ionic/utils-fs';
 import { ERROR_COMMAND_NOT_FOUND, ERROR_SIGNAL_EXIT, SubprocessError } from '@ionic/utils-subprocess';
 import * as path from 'path';
+import * as semver from 'semver';
 
 import { CommandInstanceInfo, CommandLineInputs, CommandLineOptions, IonicCapacitorOptions, ProjectIntegration } from '../../definitions';
 import { input, strong } from '../../lib/color';
@@ -31,6 +32,21 @@ export abstract class CapacitorCommand extends Command {
     }
 
     return new CapacitorConfig(path.resolve(this.project.directory, CAPACITOR_CONFIG_FILE));
+  }
+
+  async getCapacitorVersion(): Promise<semver.SemVer> {
+    if (!this.project) {
+      throw new FatalException(`Cannot use Capacitor outside a project directory..`);
+    }
+
+    const capacitor = await this.project.createIntegration('capacitor');
+    const version = semver.parse(await capacitor.getCapacitorCLIVersion());
+
+    if (!version) {
+      throw new FatalException('Error while getting Capacitor CLI version. Is Capacitor installed?');
+    }
+
+    return version;
   }
 
   async checkCapacitor(runinfo: CommandInstanceInfo) {

--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -117,21 +117,25 @@ export abstract class CapacitorCommand extends Command {
 
   async getInstalledPlatforms(): Promise<string[]> {
     const cli = await this.getCapacitorCLIConfig();
+    const androidPlatformDirAbs = cli?.android.platformDirAbs ?? path.resolve(this.integration.root, 'android');
+    const iosPlatformDirAbs = cli?.ios.platformDirAbs ?? path.resolve(this.integration.root, 'ios');
     const platforms: string[] = [];
 
-    if (!cli) {
-      return [];
-    }
-
-    if (await pathExists(cli.android.platformDirAbs)) {
+    if (await pathExists(androidPlatformDirAbs)) {
       platforms.push('android');
     }
 
-    if (await pathExists(cli.ios.platformDirAbs)) {
+    if (await pathExists(iosPlatformDirAbs)) {
       platforms.push('ios');
     }
 
     return platforms;
+  }
+
+  async isPlatformInstalled(platform: string): Promise<boolean> {
+    const platforms = await this.getInstalledPlatforms();
+
+    return platforms.includes(platform);
   }
 
   async checkCapacitor(runinfo: CommandInstanceInfo) {
@@ -234,16 +238,6 @@ export abstract class CapacitorCommand extends Command {
 
       throw e;
     }
-  }
-
-  async isPlatformInstalled(platform: string): Promise<boolean> {
-    const cli = await this.getCapacitorCLIConfig();
-
-    if (!cli || (platform !== 'android' && platform !== 'ios')) {
-      return false;
-    }
-
-    return await pathExists(cli[platform].platformDirAbs);
   }
 
   async checkForPlatformInstallation(platform: string) {

--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -47,7 +47,7 @@ export abstract class CapacitorCommand extends Command {
 
     const p = await this.getGeneratedConfigDir(platform);
 
-    return path.resolve(this.project.directory, p, CAPACITOR_CONFIG_FILE);
+    return path.resolve(this.integration.root, p, CAPACITOR_CONFIG_FILE);
   }
 
   async getAndroidManifest(): Promise<CapacitorAndroidManifest> {
@@ -88,12 +88,12 @@ export abstract class CapacitorCommand extends Command {
       return;
     }
 
-    try {
+    const configPath = path.resolve(this.integration.root, CAPACITOR_CONFIG_FILE);
+
       // fallback to reading capacitor.config.json if it exists
-      const conf = new CapacitorConfig(path.resolve(this.project.directory, CAPACITOR_CONFIG_FILE));
+    if (await pathExists(configPath)) {
+      const conf = new CapacitorConfig(configPath);
       return conf.c;
-    } catch (e) {
-      // ignore
     }
   }
 
@@ -263,7 +263,7 @@ export abstract class CapacitorCommand extends Command {
       return false;
     }
 
-    await this.env.shell.run(manager, managerArgs, { cwd: this.project.directory });
+    await this.env.shell.run(manager, managerArgs, { cwd: this.integration.root });
 
     return true;
   }

--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -107,12 +107,31 @@ export abstract class CapacitorCommand extends Command {
           throw new FatalException('Error while getting Capacitor CLI version. Is Capacitor installed?');
         }
 
-        throw new FatalException('Error while getting Capacitor CLI version.\n' + (e.output ?? e.code));
+        throw new FatalException('Error while getting Capacitor CLI version.\n' + (e.output ? e.output : e.code));
       }
 
       throw e;
     }
   });
+
+  async getInstalledPlatforms(): Promise<string[]> {
+    const cli = await this.getCapacitorCLIConfig();
+    const platforms: string[] = [];
+
+    if (!cli) {
+      return [];
+    }
+
+    if (await pathExists(cli.android.platformDirAbs)) {
+      platforms.push('android');
+    }
+
+    if (await pathExists(cli.ios.platformDirAbs)) {
+      platforms.push('ios');
+    }
+
+    return platforms;
+  }
 
   async checkCapacitor(runinfo: CommandInstanceInfo) {
     if (!this.project) {

--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -4,13 +4,13 @@ import * as path from 'path';
 import * as semver from 'semver';
 
 import { CommandInstanceInfo, CommandLineInputs, CommandLineOptions, IonicCapacitorOptions, ProjectIntegration } from '../../definitions';
-import { input, strong } from '../../lib/color';
+import { input } from '../../lib/color';
 import { Command } from '../../lib/command';
 import { FatalException, RunnerException } from '../../lib/errors';
 import { runCommand } from '../../lib/executor';
 import type { CapacitorCLIConfig, Integration as CapacitorIntegration } from '../../lib/integrations/capacitor'
 import { ANDROID_MANIFEST_FILE, CapacitorAndroidManifest } from '../../lib/integrations/capacitor/android';
-import { CAPACITOR_CONFIG_FILE, CapacitorConfig } from '../../lib/integrations/capacitor/config';
+import { CAPACITOR_CONFIG_JSON_FILE, CapacitorJSONConfig } from '../../lib/integrations/capacitor/config';
 import { generateOptionsForCapacitorBuild } from '../../lib/integrations/capacitor/utils';
 
 export abstract class CapacitorCommand extends Command {
@@ -30,14 +30,14 @@ export abstract class CapacitorCommand extends Command {
     return this._integration;
   }
 
-  async getGeneratedConfig(platform: string): Promise<CapacitorConfig> {
+  async getGeneratedConfig(platform: string): Promise<CapacitorJSONConfig> {
     if (!this.project) {
       throw new FatalException(`Cannot use Capacitor outside a project directory.`);
     }
 
     const p = await this.getGeneratedConfigPath(platform);
 
-    return new CapacitorConfig(p);
+    return new CapacitorJSONConfig(p);
   }
 
   async getGeneratedConfigPath(platform: string): Promise<string> {
@@ -47,7 +47,7 @@ export abstract class CapacitorCommand extends Command {
 
     const p = await this.getGeneratedConfigDir(platform);
 
-    return path.resolve(this.integration.root, p, CAPACITOR_CONFIG_FILE);
+    return path.resolve(this.integration.root, p, CAPACITOR_CONFIG_JSON_FILE);
   }
 
   async getAndroidManifest(): Promise<CapacitorAndroidManifest> {
@@ -165,7 +165,7 @@ export abstract class CapacitorCommand extends Command {
       this.env.log.warn(
         `Capacitor server URL is in use.\n` +
         `This may result in unexpected behavior for this build, where an external server is used in the Web View instead of your app. This likely occurred because of ${input('--livereload')} usage in the past and the CLI improperly exiting without cleaning up.\n\n` +
-        `Delete the ${input('server')} key in the ${strong(CAPACITOR_CONFIG_FILE)} file if you did not intend to use an external server.`
+        `Delete the ${input('server')} key in the Capacitor config file if you did not intend to use an external server.`
       );
       this.env.log.nl();
     }

--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -16,7 +16,6 @@ import { generateOptionsForCapacitorBuild } from '../../lib/integrations/capacit
 export abstract class CapacitorCommand extends Command {
   private _integration?: Required<ProjectIntegration>;
   private _integrationObject?: CapacitorIntegration;
-  private _cliconfig?: CapacitorCLIConfig;
 
   get integration(): Required<ProjectIntegration> {
     if (!this.project) {
@@ -77,12 +76,9 @@ export abstract class CapacitorCommand extends Command {
   }
 
   async getCapacitorCLIConfig(): Promise<CapacitorCLIConfig | undefined> {
-    if (!this._cliconfig) {
-      const capacitor = await this.getCapacitorIntegration();
-      this._cliconfig = await capacitor.getCapacitorCLIConfig();
-    }
+    const capacitor = await this.getCapacitorIntegration();
 
-    return this._cliconfig;
+    return capacitor.getCapacitorCLIConfig();
   }
 
   async getCapacitorIntegration() {

--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -9,6 +9,7 @@ import { Command } from '../../lib/command';
 import { FatalException, RunnerException } from '../../lib/errors';
 import { runCommand } from '../../lib/executor';
 import type { CapacitorCLIConfig, Integration as CapacitorIntegration } from '../../lib/integrations/capacitor'
+import { ANDROID_MANIFEST_FILE, CapacitorAndroidManifest } from '../../lib/integrations/capacitor/android';
 import { CAPACITOR_CONFIG_FILE, CapacitorConfig, CapacitorConfigFile } from '../../lib/integrations/capacitor/config';
 import { generateOptionsForCapacitorBuild } from '../../lib/integrations/capacitor/utils';
 
@@ -47,6 +48,19 @@ export abstract class CapacitorCommand extends Command {
     const p = await this.getGeneratedConfigDir(platform);
 
     return path.resolve(this.project.directory, p, CAPACITOR_CONFIG_FILE);
+  }
+
+  async getAndroidManifest(): Promise<CapacitorAndroidManifest> {
+    const p = await this.getAndroidManifestPath();
+
+    return CapacitorAndroidManifest.load(p);
+  }
+
+  async getAndroidManifestPath(): Promise<string> {
+    const cli = await this.getCapacitorCLIConfig();
+    const srcDir = cli?.android.srcDirAbs ?? 'android/app/src/main';
+
+    return path.resolve(this.integration.root, srcDir, ANDROID_MANIFEST_FILE);
   }
 
   async getGeneratedConfigDir(platform: string): Promise<string> {

--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -227,9 +227,9 @@ export abstract class CapacitorCommand extends Command {
 
       conf.setServerUrl(serverUrl);
 
-      const manifest = await this.getAndroidManifest();
-
       if (platform === 'android') {
+        const manifest = await this.getAndroidManifest();
+
         onBeforeExit(async () => {
           await manifest.reset();
         });

--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as semver from 'semver';
 
 import { CommandInstanceInfo, CommandLineInputs, CommandLineOptions, IonicCapacitorOptions, ProjectIntegration } from '../../definitions';
-import { input } from '../../lib/color';
+import { input, weak } from '../../lib/color';
 import { Command } from '../../lib/command';
 import { FatalException, RunnerException } from '../../lib/errors';
 import { runCommand } from '../../lib/executor';
@@ -13,6 +13,7 @@ import type { CapacitorCLIConfig, Integration as CapacitorIntegration } from '..
 import { ANDROID_MANIFEST_FILE, CapacitorAndroidManifest } from '../../lib/integrations/capacitor/android';
 import { CAPACITOR_CONFIG_JSON_FILE, CapacitorJSONConfig } from '../../lib/integrations/capacitor/config';
 import { generateOptionsForCapacitorBuild } from '../../lib/integrations/capacitor/utils';
+import { createPrefixedWriteStream } from '../../lib/utils/logger';
 
 export abstract class CapacitorCommand extends Command {
   private _integration?: Required<ProjectIntegration>;
@@ -121,7 +122,9 @@ export abstract class CapacitorCommand extends Command {
       throw new FatalException(`Cannot use Capacitor outside a project directory.`);
     }
 
-    await this.env.shell.run('capacitor', argList, { fatalOnNotFound: false, truncateErrorOutput: 5000, stdio: 'inherit', cwd: this.integration.root });
+    const stream = createPrefixedWriteStream(this.env.log, weak(`[capacitor]`));
+
+    await this.env.shell.run('capacitor', argList, { stream, fatalOnNotFound: false, truncateErrorOutput: 5000, cwd: this.integration.root });
   }
 
   async runBuild(inputs: CommandLineInputs, options: CommandLineOptions): Promise<void> {

--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -58,7 +58,7 @@ export abstract class CapacitorCommand extends Command {
 
   async getAndroidManifestPath(): Promise<string> {
     const cli = await this.getCapacitorCLIConfig();
-    const srcDir = cli?.android.srcDirAbs ?? 'android/app/src/main';
+    const srcDir = cli?.android.srcMainDirAbs ?? 'android/app/src/main';
 
     return path.resolve(this.integration.root, srcDir, ANDROID_MANIFEST_FILE);
   }

--- a/packages/@ionic/cli/src/commands/capacitor/build.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/build.ts
@@ -160,7 +160,7 @@ To configure your native project, see the common configuration docs[^capacitor-n
       await hook.run({
         name: hook.name,
         build: buildRunner.createOptionsFromCommandLine(inputs, options),
-        capacitor: this.createOptionsFromCommandLine(inputs, options),
+        capacitor: await this.createOptionsFromCommandLine(inputs, options),
       });
     } catch (e) {
       if (e instanceof BaseError) {

--- a/packages/@ionic/cli/src/commands/capacitor/copy.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/copy.ts
@@ -35,7 +35,7 @@ ${input('ionic capacitor copy')} will do the following:
       inputs: [
         {
           name: 'platform',
-          summary: `The platform to copy (e.g. ${['android', 'ios', 'electron'].map(v => input(v)).join(', ')})`,
+          summary: `The platform to copy (e.g. ${['android', 'ios'].map(v => input(v)).join(', ')})`,
         },
       ],
       options,

--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -219,7 +219,13 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
           choices: targets.map(t => ({ name: `${t.name} (${t.id})`, value: t.id })),
         });
 
-        // TODO: check for target missing in non-interactive
+        if (!inputs[0]) {
+          throw new FatalException(`The ${input('platform')} argument is required.`);
+        }
+
+        if (!options['target']) {
+          throw new FatalException(`The ${input('--target')} option is required.`);
+        }
       }
     }
   }

--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -251,8 +251,6 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
         await this.runServe(inputs, options);
         await this.runCapacitorOpenFlow(inputs, options);
 
-        // output can get messy with the open flow, so print this type of
-        // message again
         this.env.log.nl();
         this.env.log.info(
           'Development server will continue running until manually stopped.\n' +
@@ -262,6 +260,13 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
         await this.runCapacitor(['sync', platform]);
         await this.runServe(inputs, options);
         await this.runCapacitorRunFlow(inputs, options, { shouldSync: false });
+
+        this.env.log.nl();
+        this.env.log.info(
+          `App deployed to device!\n` +
+          'Development server will continue running until manually stopped.\n\n' +
+          chalk.yellow('Use Ctrl+C to quit this process')
+        );
       }
 
       await sleepForever();

--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -225,12 +225,6 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
 
     if (!serverUrl) {
       const details = await runner.run(runnerOpts);
-
-      if (details.externallyAccessible === false) {
-        const extra = LOCAL_ADDRESSES.includes(details.externalAddress) ? '\nEnsure you have proper port forwarding setup from your device to your computer.' : '';
-        this.env.log.warn(`Your device or emulator may not be able to access ${strong(details.externalAddress)}.${extra}\n\n`);
-      }
-
       serverUrl = `${details.protocol || 'http'}://${details.externalAddress}:${details.port}`;
     }
 

--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -247,8 +247,10 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
     const doOpenFlow = (await this.isOldCapacitor()) || options['open'] === true;
 
     if (doLiveReload) {
+      await this.runCapacitor(['sync', platform]);
+      await this.runServe(inputs, options);
+
       if (doOpenFlow) {
-        await this.runServe(inputs, options);
         await this.runCapacitorOpenFlow(inputs, options);
 
         this.env.log.nl();
@@ -257,8 +259,6 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
           chalk.yellow('Use Ctrl+C to quit this process')
         );
       } else {
-        await this.runCapacitor(['sync', platform]);
-        await this.runServe(inputs, options);
         await this.runCapacitorRunFlow(inputs, options, { shouldSync: false });
 
         this.env.log.nl();
@@ -271,12 +271,12 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
 
       await sleepForever();
     } else {
+      await this.runBuild(inputs, options);
+
       if (doOpenFlow) {
-        await this.runBuild(inputs, options);
         await this.runCapacitor(['sync', platform]);
         await this.runCapacitorOpenFlow(inputs, options);
       } else {
-        await this.runBuild(inputs, options);
         await this.runCapacitorRunFlow(inputs, options, { shouldSync: true });
       }
     }

--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -250,17 +250,19 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
       if (doOpenFlow) {
         await this.runServe(inputs, options);
         await this.runCapacitorOpenFlow(inputs, options);
+
+        // output can get messy with the open flow, so print this type of
+        // message again
+        this.env.log.nl();
+        this.env.log.info(
+          'Development server will continue running until manually stopped.\n' +
+          chalk.yellow('Use Ctrl+C to quit this process')
+        );
       } else {
         await this.runCapacitor(['sync', platform]);
         await this.runServe(inputs, options);
         await this.runCapacitorRunFlow(inputs, options, { shouldSync: false });
       }
-
-      this.env.log.nl();
-      this.env.log.info(
-        'Development server will continue running until manually stopped.\n' +
-        chalk.yellow('Use Ctrl+C to quit this process')
-      );
 
       await sleepForever();
     } else {

--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -166,7 +166,7 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
       const platform = await this.env.prompt({
         type: 'list',
         name: 'platform',
-        message: 'What platform would you like to run?',
+        message: options['list'] ? 'What platform targets would you like to list?' : 'What platform would you like to run?',
         choices: PLATFORMS,
       });
 

--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -2,6 +2,7 @@ import { BaseError, Footnote, MetadataGroup, validators } from '@ionic/cli-frame
 import { onBeforeExit, sleepForever } from '@ionic/utils-process';
 import * as chalk from 'chalk';
 import * as lodash from 'lodash';
+import * as semver from 'semver';
 
 import { AnyBuildOptions, AnyServeOptions, CapacitorRunHookName, CommandInstanceInfo, CommandLineInputs, CommandLineOptions, CommandMetadata, CommandMetadataOption, CommandPreRun } from '../../definitions';
 import { ancillary, input, strong, weak } from '../../lib/color';
@@ -167,7 +168,7 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
     }
 
     const version = await this.getCapacitorVersion();
-    const isOldCapacitor = version.major < 3;
+    const isOldCapacitor = semver.lt(version, '3.0.0-alpha.7');
 
     if (isOldCapacitor) {
       this.env.log.warn(

--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -160,6 +160,14 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
         `Please update to the latest Capacitor. Visit the docs${ancillary('[1]')} for upgrade guides.\n\n` +
         `${ancillary('[1]')}: ${strong('https://capacitorjs.com/docs/')}\n`
       );
+
+      if (options['list']) {
+        throw new FatalException(`The ${input('--list')} option is not supported with your Capacitor version.`);
+      }
+
+      if (options['target']) {
+        throw new FatalException(`The ${input('--target')} option is not supported with your Capacitor version.`);
+      }
     }
 
     if (!inputs[0]) {

--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -241,6 +241,17 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
     });
 
     conf.setServerUrl(serverUrl);
+
+    const manifest = await this.getAndroidManifest();
+
+    if (platform === 'android') {
+      onBeforeExit(async () => {
+        await manifest.reset();
+      });
+
+      manifest.enableCleartextTraffic();
+      await manifest.save();
+    }
   }
 
   protected async runCapacitorOpenFlow(inputs: CommandLineInputs, options: CommandLineOptions): Promise<void> {

--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -177,6 +177,8 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
       );
     }
 
+    await this.runCapacitor(['sync', platform]);
+
     try {
       if (options['livereload']) {
         await this.runServe(inputs, options);
@@ -231,11 +233,10 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
       serverUrl = `${details.protocol || 'http'}://${details.externalAddress}:${details.port}`;
     }
 
-    const conf = this.getCapacitorConfig();
+    const conf = await this.getGeneratedConfig(platform);
 
     onBeforeExit(async () => {
       conf.resetServerUrl();
-      await this.runCapacitor(['copy', platform]);
     });
 
     conf.setServerUrl(serverUrl);
@@ -248,7 +249,6 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
 
     const [ platform ] = inputs;
 
-    await this.runCapacitor(['copy', platform]);
     await this.runCapacitorRunHook('capacitor:run:before', inputs, options, { ...this.env, project: this.project });
 
     if (options['open'] !== false) {
@@ -279,7 +279,7 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
     const [ platform ] = inputs;
 
     await this.runCapacitorRunHook('capacitor:run:before', inputs, options, { ...this.env, project: this.project });
-    await this.runCapacitor(['run', platform, ...(typeof options['target'] === 'string' ? ['--target', options['target']] : [])]);
+    await this.runCapacitor(['run', platform, '--no-sync', ...(typeof options['target'] === 'string' ? ['--target', options['target']] : [])]);
   }
 
   protected async runCapacitorRunHook(name: CapacitorRunHookName, inputs: CommandLineInputs, options: CommandLineOptions, e: HookDeps): Promise<void> {
@@ -302,7 +302,7 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
         name: hook.name,
         serve: serveOptions,
         build: buildOptions,
-        capacitor: this.createOptionsFromCommandLine(inputs, options),
+        capacitor: await this.createOptionsFromCommandLine(inputs, options),
       });
     } catch (e) {
       if (e instanceof BaseError) {

--- a/packages/@ionic/cli/src/commands/capacitor/sync.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/sync.ts
@@ -39,7 +39,7 @@ ${input('ionic capacitor sync')} will do the following:
       inputs: [
         {
           name: 'platform',
-          summary: `The platform to sync (e.g. ${['android', 'ios', 'electron'].map(v => input(v)).join(', ')})`,
+          summary: `The platform to sync (e.g. ${['android', 'ios'].map(v => input(v)).join(', ')})`,
         },
       ],
       options,

--- a/packages/@ionic/cli/src/commands/capacitor/sync.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/sync.ts
@@ -90,7 +90,7 @@ ${input('ionic capacitor sync')} will do the following:
       await hook.run({
         name: hook.name,
         build: buildRunner.createOptionsFromCommandLine(inputs, options),
-        capacitor: this.createOptionsFromCommandLine(inputs, options),
+        capacitor: await this.createOptionsFromCommandLine(inputs, options),
       });
     } catch (e) {
       if (e instanceof BaseError) {

--- a/packages/@ionic/cli/src/commands/capacitor/update.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/update.ts
@@ -17,7 +17,7 @@ ${input('ionic capacitor update')} will do the following:
       inputs: [
         {
           name: 'platform',
-          summary: `The platform to update (e.g. ${['android', 'ios', 'electron'].map(v => input(v)).join(', ')})`,
+          summary: `The platform to update (e.g. ${['android', 'ios'].map(v => input(v)).join(', ')})`,
         },
       ],
     };

--- a/packages/@ionic/cli/src/commands/start.ts
+++ b/packages/@ionic/cli/src/commands/start.ts
@@ -539,7 +539,6 @@ Use the ${input('--type')} option to start projects using older versions of Ioni
     this.env.shell.alterPath = p => prependNodeModulesBinToPath(projectDir, p);
 
     if (!this.schema.cloned) {
-      // Default to capacitor always
       if (this.schema.type === 'react' || this.schema.type === 'vue') {
          options['capacitor'] = true;
        }

--- a/packages/@ionic/cli/src/definitions.ts
+++ b/packages/@ionic/cli/src/definitions.ts
@@ -20,6 +20,7 @@ import { ChildProcess, SpawnOptions } from 'child_process';
 import * as fs from 'fs';
 
 import type { Integration as CapacitorIntegration } from './lib/integrations/capacitor';
+import type { CapacitorConfigFile } from './lib/integrations/capacitor/config';
 import type { Integration as CordovaIntegration } from './lib/integrations/cordova';
 import type { Integration as EnterpriseIntegration } from './lib/integrations/enterprise';
 
@@ -653,14 +654,9 @@ export interface VueBuildOptions extends BuildOptions<'vue'> {
   sourcemaps?: boolean;
 }
 
-export interface IonicCapacitorOptions {
-  verbose?: boolean;
-  appId?: string;
-  appName?: string;
-  server?: {
-    url?: string;
-  };
+export interface IonicCapacitorOptions extends CapacitorConfigFile {
   '--': string[];
+  verbose?: boolean;
 }
 
 export interface IonicAngularBuildOptions extends BuildOptions<'ionic-angular'> {

--- a/packages/@ionic/cli/src/definitions.ts
+++ b/packages/@ionic/cli/src/definitions.ts
@@ -19,6 +19,10 @@ import { Subprocess, SubprocessOptions, WhichOptions } from '@ionic/utils-subpro
 import { ChildProcess, SpawnOptions } from 'child_process';
 import * as fs from 'fs';
 
+import type { Integration as CapacitorIntegration } from './lib/integrations/capacitor';
+import type { Integration as CordovaIntegration } from './lib/integrations/cordova';
+import type { Integration as EnterpriseIntegration } from './lib/integrations/enterprise';
+
 export {
   CommandLineInputs,
   CommandLineOptions,
@@ -348,6 +352,9 @@ export interface IProject {
   getDistDir(): Promise<string>;
   getInfo(): Promise<InfoItem[]>;
   detected(): Promise<boolean>;
+  createIntegration(name: 'capacitor'): Promise<CapacitorIntegration>;
+  createIntegration(name: 'cordova'): Promise<CordovaIntegration>;
+  createIntegration(name: 'enterprise'): Promise<EnterpriseIntegration>;
   createIntegration(name: IntegrationName): Promise<IIntegration<ProjectIntegration>>;
   getIntegration(name: IntegrationName): Required<ProjectIntegration> | undefined;
   requireIntegration(name: IntegrationName): Required<ProjectIntegration>;

--- a/packages/@ionic/cli/src/definitions.ts
+++ b/packages/@ionic/cli/src/definitions.ts
@@ -20,7 +20,7 @@ import { ChildProcess, SpawnOptions } from 'child_process';
 import * as fs from 'fs';
 
 import type { Integration as CapacitorIntegration } from './lib/integrations/capacitor';
-import type { CapacitorConfigFile } from './lib/integrations/capacitor/config';
+import type { CapacitorConfig } from './lib/integrations/capacitor/config';
 import type { Integration as CordovaIntegration } from './lib/integrations/cordova';
 import type { Integration as EnterpriseIntegration } from './lib/integrations/enterprise';
 
@@ -654,7 +654,7 @@ export interface VueBuildOptions extends BuildOptions<'vue'> {
   sourcemaps?: boolean;
 }
 
-export interface IonicCapacitorOptions extends CapacitorConfigFile {
+export interface IonicCapacitorOptions extends CapacitorConfig {
   '--': string[];
   verbose?: boolean;
 }

--- a/packages/@ionic/cli/src/lib/index.ts
+++ b/packages/@ionic/cli/src/lib/index.ts
@@ -82,14 +82,14 @@ export async function generateIonicEnvironment(ctx: IonicContext, pargv: string[
         group: 'utility',
         name: 'native-run',
         key: 'native_run_version',
-        value: nativeRun || 'not installed',
+        value: nativeRun || 'not installed globally',
         flair: nativeRunUpdate ? `update available: ${latestNativeRun ? success(latestNativeRun.version) : '???'}` : '',
       },
       {
         group: 'utility',
         name: 'cordova-res',
         key: 'cordova_res_version',
-        value: cordovaRes || 'not installed',
+        value: cordovaRes || 'not installed globally',
         flair: cordovaResUpdate ? `update available: ${latestCordovaRes ? success(latestCordovaRes.version) : '???'}` : '',
       },
     ];

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/android.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/android.ts
@@ -1,0 +1,93 @@
+import { readFile, writeFile, unlink } from '@ionic/utils-fs';
+import * as et from 'elementtree';
+
+export const ANDROID_MANIFEST_FILE = 'AndroidManifest.xml';
+
+export class CapacitorAndroidManifest {
+  protected _doc?: et.ElementTree;
+  protected origManifestContent?: string;
+  protected saving = false;
+
+  constructor(readonly manifestPath: string) {}
+
+  get origManifestPath(): string {
+    return `${this.manifestPath}.orig`;
+  }
+
+  get doc(): et.ElementTree {
+    if (!this._doc) {
+      throw new Error('No doc loaded.');
+    }
+
+    return this._doc;
+  }
+
+  static async load(manifestPath: string): Promise<CapacitorAndroidManifest> {
+    if (!manifestPath) {
+      throw new Error(`Must supply file path for ${ANDROID_MANIFEST_FILE}.`);
+    }
+
+    const conf = new CapacitorAndroidManifest(manifestPath);
+    await conf.reload();
+
+    return conf;
+  }
+
+  protected async reload(): Promise<void> {
+    this.origManifestContent = await readFile(this.manifestPath, { encoding: 'utf8' });
+
+    try {
+      this._doc = et.parse(this.origManifestContent);
+    } catch (e) {
+      throw new Error(`Cannot parse ${ANDROID_MANIFEST_FILE} file: ${e.stack ?? e}`);
+    }
+  }
+
+  enableCleartextTraffic() {
+    const node = this.getApplicationNode();
+    node.set('android:usesCleartextTraffic', 'true');
+  }
+
+  async reset(): Promise<void> {
+    const origManifestContent = await readFile(this.origManifestPath, { encoding: 'utf8' });
+
+    if (!this.saving) {
+      this.saving = true;
+      await writeFile(this.manifestPath, origManifestContent, { encoding: 'utf8' });
+      await unlink(this.origManifestPath);
+      this.saving = false;
+    }
+  }
+
+  async save(): Promise<void> {
+    if (!this.saving) {
+      this.saving = true;
+
+      if (this.origManifestContent) {
+        await writeFile(this.origManifestPath, this.origManifestContent, { encoding: 'utf8' });
+        this.origManifestContent = undefined;
+      }
+
+      await writeFile(this.manifestPath, this.write(), { encoding: 'utf8' });
+
+      this.saving = false;
+    }
+  }
+
+  protected getApplicationNode(): et.Element {
+    const root = this.doc.getroot();
+    const applicationNode = root.find('application');
+
+    if (!applicationNode) {
+      throw new Error(`No <application> node in ${ANDROID_MANIFEST_FILE}.`);
+    }
+
+    return applicationNode;
+  }
+
+  protected write(): string {
+    const contents = this.doc.write({ indent: 4 });
+
+    return contents;
+  }
+}

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/config.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/config.ts
@@ -1,26 +1,24 @@
 import { BaseConfig } from '@ionic/cli-framework';
 import * as lodash from 'lodash';
 
-export const CAPACITOR_CONFIG_FILE = 'capacitor.config.json';
+export const CAPACITOR_CONFIG_JSON_FILE = 'capacitor.config.json';
 
-export interface CapacitorConfigFile {
+export interface CapacitorConfig {
   appId?: string;
   appName?: string;
   webDir?: string;
   server?: {
-    cleartext?: boolean;
     url?: string;
-    originalCleartext?: boolean;
     originalUrl?: string;
   };
 }
 
-export class CapacitorConfig extends BaseConfig<CapacitorConfigFile> {
+export class CapacitorJSONConfig extends BaseConfig<CapacitorConfig> {
   constructor(p: string) {
     super(p, { spaces: '\t' });
   }
 
-  provideDefaults(config: CapacitorConfigFile): CapacitorConfigFile {
+  provideDefaults(config: CapacitorConfig): CapacitorConfig {
     return config;
   }
 

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/config.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/config.ts
@@ -16,6 +16,10 @@ export interface CapacitorConfigFile {
 }
 
 export class CapacitorConfig extends BaseConfig<CapacitorConfigFile> {
+  constructor(p: string) {
+    super(p, { spaces: '\t' });
+  }
+
   provideDefaults(config: CapacitorConfigFile): CapacitorConfigFile {
     return config;
   }

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/config.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/config.ts
@@ -29,12 +29,7 @@ export class CapacitorJSONConfig extends BaseConfig<CapacitorConfig> {
       serverConfig.originalUrl = serverConfig.url;
     }
 
-    if (typeof serverConfig.cleartext === 'boolean') {
-      serverConfig.originalCleartext = serverConfig.cleartext;
-    }
-
     serverConfig.url = url;
-    serverConfig.cleartext = true;
 
     this.set('server', serverConfig);
   }
@@ -43,16 +38,10 @@ export class CapacitorJSONConfig extends BaseConfig<CapacitorConfig> {
     const serverConfig = this.get('server') || {};
 
     delete serverConfig.url;
-    delete serverConfig.cleartext;
 
     if (serverConfig.originalUrl) {
       serverConfig.url = serverConfig.originalUrl;
       delete serverConfig.originalUrl;
-    }
-
-    if (serverConfig.originalCleartext) {
-      serverConfig.cleartext = serverConfig.originalCleartext;
-      delete serverConfig.originalCleartext;
     }
 
     if (lodash.isEmpty(serverConfig)) {

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -84,6 +84,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
 
       await this.installCapacitorCore();
       await this.installCapacitorCLI();
+      await this.installCapacitorPlugins()
 
       await mkdirp(details.root);
       await this.e.shell.run('capacitor', ['init', name, packageId, ...options], { cwd: details.root });
@@ -103,6 +104,12 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
 
   async installCapacitorCLI() {
     const [ manager, ...managerArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'install', pkg: '@capacitor/cli@next', saveDev: true });
+    await this.e.shell.run(manager, managerArgs, { cwd: this.root });
+  }
+
+  async installCapacitorPlugins() {
+    const [ manager, ...managerArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'install', pkg: ['@capacitor/haptics', '@capacitor/app', '@capacitor/keyboard'] });
+    console.log(managerArgs)
     await this.e.shell.run(manager, managerArgs, { cwd: this.root });
   }
 

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -15,7 +15,21 @@ import {
 import { input, strong } from '../../color';
 import { pkgManagerArgs } from '../../utils/npm';
 
-import { CAPACITOR_CONFIG_FILE, CapacitorConfig } from './config';
+import { CAPACITOR_CONFIG_FILE, CapacitorConfig, CapacitorConfigFile } from './config';
+
+export interface CapacitorCLIConfig {
+  android: {
+    platformDirAbs: string;
+    assetsDirAbs: string;
+  };
+  ios: {
+    platformDirAbs: string;
+    nativeTargetDirAbs: string;
+  };
+  app: {
+    extConfig: CapacitorConfigFile;
+  }
+}
 
 export class Integration extends BaseIntegration<ProjectIntegration> {
   readonly name: IntegrationName = 'capacitor';
@@ -141,5 +155,13 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
 
   async getCapacitorCLIVersion(): Promise<string | undefined> {
     return this.e.shell.cmdinfo('capacitor', ['--version'], { cwd: this.e.project.directory });
+  }
+
+  async getCapacitorCLIConfig(): Promise<CapacitorCLIConfig | undefined> {
+    const output = await this.e.shell.cmdinfo('capacitor', ['config', '--json'], { cwd: this.e.project.directory });
+
+    if (output) {
+      return JSON.parse(output);
+    }
   }
 }

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -20,6 +20,7 @@ import { CAPACITOR_CONFIG_FILE, CapacitorConfig, CapacitorConfigFile } from './c
 export interface CapacitorCLIConfig {
   android: {
     platformDirAbs: string;
+    srcDirAbs: string;
     assetsDirAbs: string;
   };
   ios: {

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -98,12 +98,12 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
   }
 
   async installCapacitorCore() {
-    const [ manager, ...managerArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'install', pkg: '@capacitor/core@next' });
+    const [ manager, ...managerArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'install', pkg: '@capacitor/core@latest' });
     await this.e.shell.run(manager, managerArgs, { cwd: this.root });
   }
 
   async installCapacitorCLI() {
-    const [ manager, ...managerArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'install', pkg: '@capacitor/cli@next', saveDev: true });
+    const [ manager, ...managerArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'install', pkg: '@capacitor/cli@latest', saveDev: true });
     await this.e.shell.run(manager, managerArgs, { cwd: this.root });
   }
 

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -1,4 +1,4 @@
-import { PackageJson, parseArgs } from '@ionic/cli-framework';
+import { parseArgs } from '@ionic/cli-framework';
 import { mkdirp, pathExists } from '@ionic/utils-fs';
 import { prettyPath } from '@ionic/utils-terminal';
 import * as chalk from 'chalk';
@@ -125,9 +125,13 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
     const [
       [ capacitorCorePkg, capacitorCorePkgPath ],
       capacitorCLIVersion,
-    ] = await (Promise.all<[PackageJson | undefined, string | undefined], string | undefined>([
+      [ capacitorIOSPkg, capacitorIOSPkgPath ],
+      [ capacitorAndroidPkg, capacitorAndroidPkgPath ],
+    ] = await (Promise.all([
       this.e.project.getPackageJson('@capacitor/core'),
       this.getCapacitorCLIVersion(),
+      this.e.project.getPackageJson('@capacitor/ios'),
+      this.e.project.getPackageJson('@capacitor/android'),
     ]));
 
     const info: InfoItem[] = [
@@ -143,6 +147,20 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
         key: 'capacitor_core_version',
         value: capacitorCorePkg ? capacitorCorePkg.version : 'not installed',
         path: capacitorCorePkgPath,
+      },
+      {
+        group: 'capacitor',
+        name: '@capacitor/ios',
+        key: 'capacitor_ios_version',
+        value: capacitorIOSPkg ? capacitorIOSPkg.version : 'not installed',
+        path: capacitorIOSPkgPath,
+      },
+      {
+        group: 'capacitor',
+        name: '@capacitor/android',
+        key: 'capacitor_android_version',
+        value: capacitorAndroidPkg ? capacitorAndroidPkg.version : 'not installed',
+        path: capacitorAndroidPkgPath,
       },
       {
         group: 'capacitor',

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -20,7 +20,7 @@ import { CapacitorJSONConfig, CapacitorConfig } from './config';
 export interface CapacitorCLIConfig {
   android: {
     platformDirAbs: string;
-    srcDirAbs: string;
+    srcMainDirAbs: string;
     assetsDirAbs: string;
   };
   ios: {

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -108,12 +108,14 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
 
   async personalize({ name, packageId }: ProjectPersonalizationDetails) {
     const confPath = this.getCapacitorConfigJsonPath();
-    const conf = new CapacitorJSONConfig(confPath);
+    if (await pathExists(confPath)) {
+      const conf = new CapacitorJSONConfig(confPath);
 
-    conf.set('appName', name);
+      conf.set('appName', name);
 
-    if (packageId) {
-      conf.set('appId', packageId);
+      if (packageId) {
+        conf.set('appId', packageId);
+      }
     }
   }
 

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -15,7 +15,7 @@ import {
 import { input, strong } from '../../color';
 import { pkgManagerArgs } from '../../utils/npm';
 
-import { CAPACITOR_CONFIG_FILE, CapacitorConfig, CapacitorConfigFile } from './config';
+import { CapacitorJSONConfig, CapacitorConfig } from './config';
 
 export interface CapacitorCLIConfig {
   android: {
@@ -28,7 +28,7 @@ export interface CapacitorCLIConfig {
     nativeTargetDirAbs: string;
   };
   app: {
-    extConfig: CapacitorConfigFile;
+    extConfig: CapacitorConfig;
   }
 }
 
@@ -86,7 +86,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
   }
 
   protected getCapacitorConfigJsonPath(): string {
-    return path.resolve(this.config.get('root', this.e.project.directory), CAPACITOR_CONFIG_FILE);
+    return path.resolve(this.config.get('root', this.e.project.directory), 'capacitor.config.json');
   }
 
   async installCapacitorCore() {
@@ -101,7 +101,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
 
   async personalize({ name, packageId }: ProjectPersonalizationDetails) {
     const confPath = this.getCapacitorConfigJsonPath();
-    const conf = new CapacitorConfig(confPath);
+    const conf = new CapacitorJSONConfig(confPath);
 
     conf.set('appName', name);
 
@@ -160,7 +160,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
     }
   }
 
-  async getCapacitorConfig(): Promise<CapacitorConfigFile | undefined> {
+  async getCapacitorConfig(): Promise<CapacitorConfig | undefined> {
     // try using `capacitor config --json`
     const cli = await this.getCapacitorCLIConfig();
 
@@ -172,7 +172,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
 
       // fallback to reading capacitor.config.json if it exists
     if (await pathExists(confPath)) {
-      const conf = new CapacitorConfig(confPath);
+      const conf = new CapacitorJSONConfig(confPath);
       return conf.c;
     }
   }

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -81,7 +81,6 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
       }
 
       options.push('--web-dir', webDir);
-      options.push('--npm-client', this.e.config.get('npmClient'));
 
       await this.installCapacitorCore();
       await this.installCapacitorCLI();
@@ -98,12 +97,12 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
   }
 
   async installCapacitorCore() {
-    const [ manager, ...managerArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'install', pkg: '@capacitor/core' });
+    const [ manager, ...managerArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'install', pkg: '@capacitor/core@next' });
     await this.e.shell.run(manager, managerArgs, { cwd: this.root });
   }
 
   async installCapacitorCLI() {
-    const [ manager, ...managerArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'install', pkg: '@capacitor/cli', saveDev: true });
+    const [ manager, ...managerArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'install', pkg: '@capacitor/cli@next', saveDev: true });
     await this.e.shell.run(manager, managerArgs, { cwd: this.root });
   }
 

--- a/packages/@ionic/cli/src/lib/integrations/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/index.ts
@@ -19,6 +19,9 @@ import {
 import { isIntegrationName } from '../../guards';
 import { strong } from '../color';
 import { IntegrationNotFoundException } from '../errors';
+import type { Integration as CapacitorIntegration } from './capacitor';
+import type { Integration as CordovaIntegration } from './cordova';
+import type { Integration as EnterpriseIntegration } from './enterprise';
 
 export { INTEGRATION_NAMES } from '../../guards';
 
@@ -36,8 +39,6 @@ export interface IntegrationDeps {
   readonly log: ILogger;
 }
 
-export type IntegationUnion = import('./capacitor').Integration | import('./cordova').Integration | import('./enterprise').Integration;
-
 export class IntegrationConfig extends BaseConfig<ProjectIntegration> {
   provideDefaults(c: Partial<Readonly<ProjectIntegration>>): ProjectIntegration {
     return {};
@@ -52,11 +53,11 @@ export abstract class BaseIntegration<T extends ProjectIntegration> implements I
 
   constructor(protected readonly e: IntegrationDeps) {}
 
-  static async createFromName(deps: IntegrationDeps, name: 'capacitor'): Promise<import('./capacitor').Integration>;
-  static async createFromName(deps: IntegrationDeps, name: 'cordova'): Promise<import('./cordova').Integration>;
-  static async createFromName(deps: IntegrationDeps, name: 'enterprise'): Promise<import('./enterprise').Integration>;
-  static async createFromName(deps: IntegrationDeps, name: IntegrationName): Promise<IIntegration<ProjectIntegration>>;
-  static async createFromName(deps: IntegrationDeps, name: IntegrationName): Promise<IntegationUnion> {
+  static async createFromName(deps: IntegrationDeps, name: 'capacitor'): Promise<CapacitorIntegration>;
+  static async createFromName(deps: IntegrationDeps, name: 'cordova'): Promise<CordovaIntegration>;
+  static async createFromName(deps: IntegrationDeps, name: 'enterprise'): Promise<EnterpriseIntegration>;
+  static async createFromName(deps: IntegrationDeps, name: IntegrationName): Promise<CapacitorIntegration | CordovaIntegration | EnterpriseIntegration>;
+  static async createFromName(deps: IntegrationDeps, name: IntegrationName): Promise<CapacitorIntegration | CordovaIntegration | EnterpriseIntegration> {
     if (isIntegrationName(name)) {
       const { Integration } = await import(`./${name}`);
       return new Integration(deps);

--- a/packages/@ionic/cli/src/lib/project/index.ts
+++ b/packages/@ionic/cli/src/lib/project/index.ts
@@ -549,8 +549,8 @@ export abstract class Project implements IProject {
   async getDistDir(): Promise<string> {
     if (this.getIntegration('capacitor') !== undefined) {
       const capacitor = await this.createIntegration('capacitor');
-      const conf = await capacitor.getCapacitorCLIConfig();
-      const webDir = conf?.app.extConfig.webDir;
+      const conf = await capacitor.getCapacitorConfig();
+      const webDir = conf?.webDir;
 
       if (webDir) {
         return path.resolve(this.directory, webDir);

--- a/packages/@ionic/cli/src/lib/project/index.ts
+++ b/packages/@ionic/cli/src/lib/project/index.ts
@@ -16,6 +16,9 @@ import { BaseException, FatalException, IntegrationNotFoundException, RunnerNotF
 import { BaseIntegration } from '../integrations';
 import { CAPACITOR_CONFIG_FILE, CapacitorConfig } from '../integrations/capacitor/config';
 import { Color } from '../utils/color';
+import type { Integration as CapacitorIntegration } from '../integrations/capacitor';
+import type { Integration as CordovaIntegration } from '../integrations/cordova';
+import type { Integration as EnterpriseIntegration } from '../integrations/enterprise';
 
 const debug = Debug('ionic:lib:project');
 
@@ -717,7 +720,11 @@ export abstract class Project implements IProject {
     registry.register(new ailments.CordovaPlatformsCommitted(deps));
   }
 
-  async createIntegration(name: IntegrationName): Promise<IIntegration<ProjectIntegration>> {
+  async createIntegration(name: 'capacitor'): Promise<CapacitorIntegration>;
+  async createIntegration(name: 'cordova'): Promise<CordovaIntegration>;
+  async createIntegration(name: 'enterprise'): Promise<EnterpriseIntegration>;
+  async createIntegration(name: IntegrationName): Promise<CapacitorIntegration | CordovaIntegration | EnterpriseIntegration>;
+  async createIntegration(name: IntegrationName): Promise<CapacitorIntegration | CordovaIntegration | EnterpriseIntegration> {
     return BaseIntegration.createFromName({
       client: this.e.client,
       config: this.e.config,

--- a/packages/@ionic/cli/src/lib/project/index.ts
+++ b/packages/@ionic/cli/src/lib/project/index.ts
@@ -14,7 +14,6 @@ import { isMultiProjectConfig, isProjectConfig } from '../../guards';
 import { ancillary, failure, input, strong } from '../color';
 import { BaseException, FatalException, IntegrationNotFoundException, RunnerNotFoundException } from '../errors';
 import { BaseIntegration } from '../integrations';
-import { CAPACITOR_CONFIG_FILE, CapacitorConfig } from '../integrations/capacitor/config';
 import { Color } from '../utils/color';
 import type { Integration as CapacitorIntegration } from '../integrations/capacitor';
 import type { Integration as CordovaIntegration } from '../integrations/cordova';
@@ -549,13 +548,15 @@ export abstract class Project implements IProject {
 
   async getDistDir(): Promise<string> {
     if (this.getIntegration('capacitor') !== undefined) {
-      const conf = new CapacitorConfig(path.resolve(this.directory, CAPACITOR_CONFIG_FILE));
-      const webDir = conf.get('webDir');
+      const capacitor = await this.createIntegration('capacitor');
+      const conf = await capacitor.getCapacitorCLIConfig();
+      const webDir = conf?.app.extConfig.webDir;
+
       if (webDir) {
         return path.resolve(this.directory, webDir);
       } else {
         throw new FatalException(
-          `The ${input('webDir')} property must be set in the Capacitor configuration file (${input(CAPACITOR_CONFIG_FILE)}). \n` +
+          `The ${input('webDir')} property must be set in the Capacitor configuration file. \n` +
           `See the Capacitor docs for more information: ${strong('https://capacitor.ionicframework.com/docs/basics/configuring-your-app')}`
         );
       }

--- a/packages/@ionic/cli/src/lib/project/index.ts
+++ b/packages/@ionic/cli/src/lib/project/index.ts
@@ -553,7 +553,7 @@ export abstract class Project implements IProject {
       const webDir = conf?.webDir;
 
       if (webDir) {
-        return path.resolve(this.directory, webDir);
+        return path.resolve(capacitor.root, webDir);
       } else {
         throw new FatalException(
           `The ${input('webDir')} property must be set in the Capacitor configuration file. \n` +

--- a/packages/@ionic/cli/src/lib/shell.ts
+++ b/packages/@ionic/cli/src/lib/shell.ts
@@ -33,8 +33,6 @@ export class Shell implements IShell {
   }
 
   async run(command: string, args: readonly string[], { stream, killOnExit = true, showCommand = true, showError = true, fatalOnNotFound = true, fatalOnError = true, truncateErrorOutput, ...crossSpawnOptions }: IShellRunOptions): Promise<void> {
-    this.prepareSpawnOptions(crossSpawnOptions);
-
     const proc = await this.createSubprocess(command, args, crossSpawnOptions);
 
     const fullCmd = proc.bashify();
@@ -186,8 +184,6 @@ export class Shell implements IShell {
   }
 
   async spawn(command: string, args: readonly string[], { showCommand = true, ...crossSpawnOptions }: IShellSpawnOptions): Promise<ChildProcess> {
-    this.prepareSpawnOptions(crossSpawnOptions);
-
     const proc = await this.createSubprocess(command, args, crossSpawnOptions);
     const p = proc.spawn();
 
@@ -200,7 +196,6 @@ export class Shell implements IShell {
 
   async cmdinfo(command: string, args: readonly string[] = []): Promise<string | undefined> {
     const opts: IShellSpawnOptions = {};
-    this.prepareSpawnOptions(opts);
 
     const proc = await this.createSubprocess(command, args, opts);
 
@@ -213,6 +208,7 @@ export class Shell implements IShell {
   }
 
   async createSubprocess(command: string, args: readonly string[] = [], options: SubprocessOptions = {}): Promise<Subprocess> {
+    this.prepareSpawnOptions(options);
     const cmdpath = await this.resolveCommandPath(command, options);
     const proc = new Subprocess(cmdpath, args, options);
 

--- a/packages/@ionic/cli/src/lib/utils/npm.ts
+++ b/packages/@ionic/cli/src/lib/utils/npm.ts
@@ -24,7 +24,7 @@ export type PkgManagerCommand = 'dedupe' | 'rebuild' | 'install' | 'uninstall' |
 
 export interface PkgManagerOptions {
   command: PkgManagerCommand;
-  pkg?: string;
+  pkg?: string | string[];
   script?: string;
   scriptArgs?: string[];
   global?: boolean;
@@ -134,7 +134,12 @@ export async function pkgManagerArgs(npmClient: NpmClient, options: PkgManagerOp
   }
 
   if (options.pkg) {
-    installerArgs.push(options.pkg);
+    if (typeof options.pkg === 'string'){
+      installerArgs.push(options.pkg);
+    }
+    if (Array.isArray(options.pkg)){
+      installerArgs.push(...options.pkg)
+    }
   }
 
   if (cmd === 'run' && options.script) {


### PR DESCRIPTION
TODO:
- [x] investigate editing android module's AndroidManifest.xml instead of app's
- [x] `ionic start` should use Capacitor 3

This PR adds support for Capacitor 3 in the Ionic CLI, necessary because of changes in Capacitor such as dynamic configuration and the availability of the `capacitor run` command.

This will require Capacitor version **3.0.0-alpha.7** or greater to test.

**Summary of Changes**
- `ionic cap run` will use `capacitor run` if available.
    - New `--target` option for targeting a specific device.
    - New `--list` option for listing target devices.
    - New `--open` option to use old flow of running `capacitor sync` and `capacitor open` (instead of `capacitor run`)
- `ionic cap run` will now edit the native platform's generated `capacitor.config.json` files to insert `server.url`.
- `ionic cap run` will no longer use Capacitor's `cleartext` option, but instead manually edit the app's `AndroidManifest.xml` and restore the file after the command is done.
    - `cleartext` is a Capacitor CLI option that takes effect during `capacitor sync`, but with dynamic configuration files we can no longer reliably edit the main config file.
- Capacitor configuration is first loaded via (hidden) `capacitor config` command, then falls back to trying to read `capacitor.config.json`.