### PR TITLE
feat(appflow): support Capacitor only apps with `ionic deploy manifest`

### DIFF
--- a/packages/@ionic/cli/src/commands/deploy/capacitor.ts
+++ b/packages/@ionic/cli/src/commands/deploy/capacitor.ts
@@ -1,0 +1,66 @@
+import { BaseConfig } from "@ionic/cli-framework";
+import lodash = require("lodash");
+
+export interface CapacitorConfig {
+  appId?: string;
+  appName?: string;
+  webDir?: string;
+  server?: {
+    url?: string;
+    originalUrl?: string;
+  };
+}
+
+export interface CapacitorCLIConfig {
+  android: {
+    platformDirAbs: string;
+    srcMainDirAbs: string;
+    assetsDirAbs: string;
+  };
+  ios: {
+    platformDirAbs: string;
+    nativeTargetDirAbs: string;
+  };
+  app: {
+    extConfig: CapacitorConfig;
+  };
+}
+
+export class CapacitorJSONConfig extends BaseConfig<CapacitorConfig> {
+  constructor(p: string) {
+    super(p, { spaces: "\t" });
+  }
+
+  provideDefaults(config: CapacitorConfig): CapacitorConfig {
+    return config;
+  }
+
+  setServerUrl(url: string): void {
+    const serverConfig = this.get("server") || {};
+
+    if (typeof serverConfig.url === "string") {
+      serverConfig.originalUrl = serverConfig.url;
+    }
+
+    serverConfig.url = url;
+
+    this.set("server", serverConfig);
+  }
+
+  resetServerUrl(): void {
+    const serverConfig = this.get("server") || {};
+
+    delete serverConfig.url;
+
+    if (serverConfig.originalUrl) {
+      serverConfig.url = serverConfig.originalUrl;
+      delete serverConfig.originalUrl;
+    }
+
+    if (lodash.isEmpty(serverConfig)) {
+      this.unset("server");
+    } else {
+      this.set("server", serverConfig);
+    }
+  }
+}

--- a/packages/@ionic/cli/src/commands/deploy/manifest.ts
+++ b/packages/@ionic/cli/src/commands/deploy/manifest.ts
@@ -1,16 +1,25 @@
 import { MetadataGroup } from '@ionic/cli-framework';
+import { LOGGER_LEVELS } from '@ionic/cli-framework-output';
 import { map } from '@ionic/utils-array';
-import { readdirp, stat, writeFile } from '@ionic/utils-fs';
+import { pathExists, readdirp, stat, writeFile } from '@ionic/utils-fs';
 import { prettyPath } from '@ionic/utils-terminal';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
+import lodash = require('lodash');
 import * as path from 'path';
+import * as Debug from 'debug';
 
 import { CommandMetadata } from '../../definitions';
 import { input } from '../../lib/color';
 import { FatalException } from '../../lib/errors';
+import { prependNodeModulesBinToPath, Shell } from '../../lib/shell';
+import { createDefaultLoggerHandlers, Logger } from '../../lib/utils/logger';
 
+import { CapacitorCLIConfig, CapacitorConfig, CapacitorJSONConfig } from './capacitor';
 import { DeployCoreCommand } from './core';
+
+const debug = Debug('ionic:commands:deploy:manifest');
+const CAPACITOR_CONFIG_JSON_FILE = 'capacitor.config.json';
 
 interface DeployManifestItem {
   href: string;
@@ -20,21 +29,29 @@ interface DeployManifestItem {
 
 export class DeployManifestCommand extends DeployCoreCommand {
   async getMetadata(): Promise<CommandMetadata> {
+    // This command is set as type 'global' in order to support Capacitor apps without an ionic.config.json
     return {
       name: 'manifest',
-      type: 'project',
+      type: 'global',
       summary: 'Generates a manifest file for the deploy service from a built app directory',
       groups: [MetadataGroup.PAID],
     };
   }
 
   async run(): Promise<void> {
-    if (!this.project) {
+    const capacitorConfig = await this.getCapacitorConfig();
+    if (!this.project && !capacitorConfig) {
       throw new FatalException(`Cannot run ${input('ionic deploy manifest')} outside a project directory.`);
     }
-    await this.requireNativeIntegration();
 
-    const buildDir = await this.project.getDistDir();
+    let buildDir: string;
+    if (this.project) {
+      await this.requireNativeIntegration();
+      buildDir = await this.project.getDistDir();
+    } else {
+      buildDir = capacitorConfig!.webDir ? capacitorConfig!.webDir : 'www';
+    }
+
     const manifest = await this.getFilesAndSizesAndHashesForGlobPattern(buildDir);
 
     const manifestPath = path.resolve(buildDir, 'pro-manifest.json');
@@ -83,4 +100,55 @@ export class DeployManifestCommand extends DeployCoreCommand {
       })
       .join(' ');
   }
+
+  private getCapacitorConfigJsonPath(): string {
+    return path.resolve(this.env.ctx.execPath, CAPACITOR_CONFIG_JSON_FILE);
+  }
+
+  private getCapacitorCLIConfig = lodash.memoize(async (): Promise<CapacitorCLIConfig | undefined> => {
+    // I had to create a new shell to force prependNodeModulesBinToPath.
+    // If ionic.config.json is not present, then this.env.shell will not implement this, and the Capacitor command will fail.
+    const args = ['config', '--json'];
+    const log = new Logger({
+      level: LOGGER_LEVELS.INFO,
+      handlers: createDefaultLoggerHandlers(),
+    });
+    const shell = new Shell({ log }, { alterPath: p => { return prependNodeModulesBinToPath(this.env.ctx.execPath, p)} });
+
+    debug('Getting config with Capacitor CLI: %O', args);
+
+    const output = await shell.cmdinfo('capacitor', args);
+
+    if (!output) {
+      debug('Could not get config from Capacitor CLI (probably old version)');
+      return;
+    }
+
+    return JSON.parse(output);
+  });
+
+  private getCapacitorConfig = lodash.memoize(async (): Promise<CapacitorConfig | undefined> => {
+    const cli = await this.getCapacitorCLIConfig();
+
+    if (cli) {
+      debug('Loaded Capacitor config!');
+      return cli.app.extConfig;
+    }
+
+    // fallback to reading capacitor.config.json if it exists
+    const confPath = this.getCapacitorConfigJsonPath();
+
+    if (!(await pathExists(confPath))) {
+      debug('Capacitor config file does not exist at %O', confPath);
+      debug('Failed to load Capacitor config');
+      return;
+    }
+
+    const conf = new CapacitorJSONConfig(confPath);
+    const extConfig = conf.c;
+
+    debug('Loaded Capacitor config!');
+
+    return extConfig;
+  });
 }


### PR DESCRIPTION
This change is mainly for people who want to build their apps in Appflow. The Appflow runners call the `ionic deploy manifest` command during the build process, and we are currently updating Appflow to support non-Ionic Capacitor apps. This command is necessary for our flow, but only relies on the Capacitor build directory, so being able to fallback onto a Capacitor config works for this scenario.