### PR TITLE
fix(appflow): Default should be all available not hard-coded by platform

### DIFF
--- a/packages/@ionic/cli/src/commands/package/build.ts
+++ b/packages/@ionic/cli/src/commands/package/build.ts
@@ -345,7 +345,7 @@ if you do not wish to download ${input('apk')}.
       }
 
       if (errors.length) {
-        errors.forEach((error) => this.env.log.error(error.message));
+        throw new FatalException(`There were issues downloading artifacts: ${errors.join('\n')}`);
       }
 
     } else if (typeof options['artifact-type'] == 'string') {
@@ -498,7 +498,7 @@ if you do not wish to download ${input('apk')}.
     const url = await this.getDownloadUrl(appflowId, buildId, artifactType.toUpperCase(), token);
 
     if (!url.url) {
-      throw new Error('Missing URL in response');
+      throw new Error(`Artifact type '${artifactType}' not found`);
     }
 
     let customBuildFileName = '';


### PR DESCRIPTION
Main issue here is that by default an `AAB` or `DSYM` artifact may not be available and under those circumstances we don't want the CLI to error because it tried to download every artifact that the platform _could_ produce. Instead download the artifacts that we _know_ the build produced by default.

Changes:
- `Artifact Type(s):` log output by default should not try to anticipate what artifacts we _could_ build and instead say `all available` or `not set` or something to let the user know we will download what we can.
- Default behavior uses the build output to find available artifact types instead of hard-coded.
- Multiple artifact requests delay failing only once all downloads are attempted
- Single artifact requests should work as it did before