### PR TITLE
fix(appflow): fix deploy manifest for Capacitor 1.x apps

### DIFF
--- a/packages/@ionic/cli/src/commands/deploy/manifest.ts
+++ b/packages/@ionic/cli/src/commands/deploy/manifest.ts
@@ -124,7 +124,12 @@ export class DeployManifestCommand extends DeployCoreCommand {
       return;
     }
 
-    return JSON.parse(output);
+    try {
+      return JSON.parse(output);
+    } catch(e) {
+      debug('Could not get config from Capacitor CLI (probably old version)', e);
+      return;
+    }
   });
 
   private getCapacitorConfig = lodash.memoize(async (): Promise<CapacitorConfig | undefined> => {


### PR DESCRIPTION
Capacitor 2.x apps would throw a status code of 1 with `capacitor config --json` and the `output` variable in this case would be undefined. However, on Capacitor 1.x apps this results in a status code of 0 and the `output` variable is populated with text that we weren't expecting. This change will ensure that the output of that command can be parsed into JSON, in which we should reliably know that the user is using Capacitor 3.x and that we can retrieve their config from this command while supporting Capacitor 1.x and 2.x as well.