### PR TITLE
fix(#3965): give --lab access to serve externalAddress

### DIFF
--- a/packages/@ionic/cli/src/lib/serve.ts
+++ b/packages/@ionic/cli/src/lib/serve.ts
@@ -672,7 +672,7 @@ class IonicLabServeCLI extends ServeCLI<IonicLabServeCLIOptions> {
 
     const pkg = await this.e.project.requirePackageJson();
 
-    const url = `${serveDetails.protocol}://localhost:${serveDetails.port}`;
+    const url = `${serveDetails.protocol}://${serveDetails.externalAddress}:${serveDetails.port}`;
     const appName = this.e.project.config.get('name');
     const labArgs = [url, '--host', labDetails.host, '--port', String(labDetails.port), '--project-type', labDetails.projectType];
     const nameArgs = appName ? ['--app-name', appName] : [];


### PR DESCRIPTION
This should fix a bug where lab is trying to always grab content
from localhost even if the content is hosted on a different address.

This should help with accessing lab on an external network in a browser
when say for extample the ionic-cli is running on ubuntu server, where a
browser is not available.

The reason we will use `serveDetails.externalAddress` instead of
`labDetails.host` is because `serve` is where we will be getting our content
from and by default is hosted on a seperate port from lab.

This change should not break anything since `serveDetails.externalAddress`
will default to the initial `localhost` if no --host argument is passed.

## Before

![nw-console](https://user-images.githubusercontent.com/20132952/108935081-cbe4cf80-7655-11eb-816b-b65d730a0ddf.PNG)
![nw-browser](https://user-images.githubusercontent.com/20132952/108935113-d8692800-7655-11eb-954b-77a2b0c7eeba.PNG)

## After

![w-console](https://user-images.githubusercontent.com/20132952/108935314-2da53980-7656-11eb-9b1c-4a34534bc5dc.PNG)
![w-browser](https://user-images.githubusercontent.com/20132952/108935342-372ea180-7656-11eb-98da-493fb869491d.PNG)




