### PR TITLE
Don't create capacitor.config.json if it doesn't exist

### DIFF
--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -108,12 +108,14 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
 
   async personalize({ name, packageId }: ProjectPersonalizationDetails) {
     const confPath = this.getCapacitorConfigJsonPath();
-    const conf = new CapacitorJSONConfig(confPath);
+    if (await pathExists(confPath)) {
+      const conf = new CapacitorJSONConfig(confPath);
 
-    conf.set('appName', name);
+      conf.set('appName', name);
 
-    if (packageId) {
-      conf.set('appId', packageId);
+      if (packageId) {
+        conf.set('appId', packageId);
+      }
     }
   }
 


### PR DESCRIPTION
`personalize` method was supposed to edit the `capacitor.config.json` config values, but since capacitor creates a .ts file now, the CLI is creating a new `capacitor.config.json` file, so this will check if the exists and overwrite on it only if it exists, but don't create a new one.

But I don't think we need the `personalize` method at all as the `appName` and `appId` are already passed to capacitor init command. I've tried to look into it and ended in commits that din't explain why it was included, so didn't remove it just in case it's used somewhere else.
