### PR TITLE
fix(capacitor): Make add use latest instead of next

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -273,7 +273,7 @@ export abstract class CapacitorCommand extends Command {
     }
 
     if (semver.gte(version, '3.0.0-alpha.1')) {
-      const [ manager, ...managerArgs ] = await pkgManagerArgs(this.env.config.get('npmClient'), { command: 'install', pkg: `@capacitor/${platform}@next`, saveDev: true });
+      const [ manager, ...managerArgs ] = await pkgManagerArgs(this.env.config.get('npmClient'), { command: 'install', pkg: `@capacitor/${platform}@latest`, saveDev: false });
       await this.env.shell.run(manager, managerArgs, { cwd: this.integration.root });
     }
 


### PR DESCRIPTION
Also install the platforms as dependencies and not as dev dependencies, since that's what we recommend on Capacitor docs

closes https://github.com/ionic-team/ionic-cli/issues/4699