### PR TITLE
fix: Add status-bar to plugins installed on capacitor integration

### DIFF
--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -108,7 +108,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
   }
 
   async installCapacitorPlugins() {
-    const [ manager, ...managerArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'install', pkg: ['@capacitor/haptics', '@capacitor/app', '@capacitor/keyboard'] });
+    const [ manager, ...managerArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'install', pkg: ['@capacitor/haptics', '@capacitor/app', '@capacitor/keyboard', '@capacitor/status-bar'] });
     await this.e.shell.run(manager, managerArgs, { cwd: this.root });
   }
 


### PR DESCRIPTION
ionic relies on statustap event from @capacitor/status-bar plugin to scroll to top when the status bar is tapped