### PR TITLE
fix: update package-lock.json when the --no-deps flag is used

### DIFF
--- a/packages/@ionic/cli/src/commands/start.ts
+++ b/packages/@ionic/cli/src/commands/start.ts
@@ -592,6 +592,17 @@ Use the ${input('--type')} option to start projects using older versions of Ioni
 
       const [installer, ...installerArgs] = await pkgManagerArgs(this.env.config.get('npmClient'), { command: 'install' });
       await this.env.shell.run(installer, installerArgs, shellOptions);
+    } else {
+      // --no-deps flag was used so skip installing dependencies, but update the lock file so that it's in sync with the package.json
+      this.env.log.msg('Updating lockfile.');
+      if (this.env.config.get('npmClient') === 'yarn') {
+        // Yarn doesn't have an out of the box way to update the lock file without performing an install so warn the user that the lockfile might be out of date
+        this.env.log.warn('Unable to update `yarn.lock` without installing dependencies. `yarn.lock` may be out of sync.');
+      } else {
+        // Perform an install that updates the lockfile without installing dependencies.
+        const [installer, ...installerArgs] = await pkgManagerArgs(this.env.config.get('npmClient'), { command: 'install', lockFileOnly: true });
+        await this.env.shell.run(installer, installerArgs, shellOptions);
+      }
     }
 
     if (!this.schema.cloned) {

--- a/packages/@ionic/cli/src/lib/utils/__tests__/npm.ts
+++ b/packages/@ionic/cli/src/lib/utils/__tests__/npm.ts
@@ -77,6 +77,11 @@ describe('@ionic/cli', () => {
         expect(result).toEqual(['npm', 'info', '@ionic/cli', '--json']);
       });
 
+      it('should include lockFileOnly flag', async () => {
+        const result = await pkgManagerArgs('npm', { command: 'install', lockFileOnly: true });
+        expect(result).toEqual(['npm', 'i', '--package-lock-only']);
+      });
+
       describe('yarn', () => {
 
         jest.resetModules();
@@ -229,6 +234,10 @@ describe('@ionic/cli', () => {
           expect(result).toEqual(['pnpm', 'info',  '@ionic/cli', '--json']);
         });
 
+        it('should include lockFileOnly flag', async () => {
+          const result = await pkgManagerArgs('pnpm', { command: 'install', lockFileOnly: true });
+          expect(result).toEqual(['pnpm', 'install', '--lockfile-only']);
+        });
       });
 
     });

--- a/packages/@ionic/cli/src/lib/utils/npm.ts
+++ b/packages/@ionic/cli/src/lib/utils/npm.ts
@@ -18,6 +18,7 @@ interface PkgManagerVocabulary {
   saveDev: string;
   saveExact: string;
   nonInteractive: string;
+  lockFileOnly: string;
 }
 
 export type PkgManagerCommand = 'dedupe' | 'rebuild' | 'install' | 'uninstall' | 'run' | 'info';
@@ -32,6 +33,7 @@ export interface PkgManagerOptions {
   saveDev?: boolean;
   saveExact?: boolean;
   json?: boolean;
+  lockFileOnly?: boolean;
 }
 
 /**
@@ -78,16 +80,16 @@ export async function pkgManagerArgs(npmClient: NpmClient, options: PkgManagerOp
 
   switch (npmClient) {
     case 'npm':
-      vocab = { run: 'run', install: 'i', bareInstall: 'i', uninstall: 'uninstall', dedupe: 'dedupe', rebuild: 'rebuild', global: '-g', save: '--save', saveDev: '-D', saveExact: '-E', nonInteractive: '' };
+      vocab = { run: 'run', install: 'i', bareInstall: 'i', uninstall: 'uninstall', dedupe: 'dedupe', rebuild: 'rebuild', global: '-g', save: '--save', saveDev: '-D', saveExact: '-E', nonInteractive: '', lockFileOnly: '--package-lock-only' };
       break;
     case 'yarn':
-      vocab = { run: 'run', install: 'add', bareInstall: 'install', uninstall: 'remove', dedupe: '', rebuild: 'install', global: '', save: '', saveDev: '--dev', saveExact: '--exact', nonInteractive: '--non-interactive' };
+      vocab = { run: 'run', install: 'add', bareInstall: 'install', uninstall: 'remove', dedupe: '', rebuild: 'install', global: '', save: '', saveDev: '--dev', saveExact: '--exact', nonInteractive: '--non-interactive', lockFileOnly: '' };
       if (options.global) { // yarn installs packages globally under the 'global' prefix, instead of having a flag
         installerArgs.push('global');
       }
       break;
     case 'pnpm':
-      vocab = { run: 'run', install: 'add', bareInstall: 'install', uninstall: 'remove', dedupe: '', rebuild: 'rebuild', global: '--global', save: '', saveDev: '--save-dev', saveExact: '--save-exact', nonInteractive: '' };
+      vocab = { run: 'run', install: 'add', bareInstall: 'install', uninstall: 'remove', dedupe: '', rebuild: 'rebuild', global: '--global', save: '', saveDev: '--save-dev', saveExact: '--save-exact', nonInteractive: '', lockFileOnly: '--lockfile-only' };
       break;
     default:
       throw new Error(`unknown installer: ${npmClient}`);
@@ -98,6 +100,9 @@ export async function pkgManagerArgs(npmClient: NpmClient, options: PkgManagerOp
       installerArgs.push(vocab.install);
     } else {
       installerArgs.push(vocab.bareInstall);
+    }
+    if (options.lockFileOnly) {
+      installerArgs.push(vocab.lockFileOnly)
     }
   } else if (cmd === 'uninstall') {
     installerArgs.push(vocab.uninstall);


### PR DESCRIPTION
updated `ionic start` to update the package-lock.json when the --no-deps flag is passed