### PR TITLE
docs: Rename Ionic Appflow to Appflow

### DIFF
--- a/packages/@ionic/cli/src/commands/deploy/build.ts
+++ b/packages/@ionic/cli/src/commands/deploy/build.ts
@@ -48,7 +48,7 @@ export class BuildCommand extends Command {
       groups: [MetadataGroup.PAID],
       summary: 'Create a deploy build on Appflow',
       description: `
-This command creates a deploy build on Ionic Appflow. While the build is running, it prints the remote build log to the terminal. If the build is successful, it downloads the created web build zip file in the current directory. Downloading build artifacts can be skipped by supplying the flag ${input('skip-download')}.
+This command creates a deploy build on Appflow. While the build is running, it prints the remote build log to the terminal. If the build is successful, it downloads the created web build zip file in the current directory. Downloading build artifacts can be skipped by supplying the flag ${input('skip-download')}.
 
 Apart from ${input('--commit')}, every option can be specified using the full name setup within the Appflow Dashboard[^dashboard].
 

--- a/packages/@ionic/cli/src/commands/git/remote.ts
+++ b/packages/@ionic/cli/src/commands/git/remote.ts
@@ -13,9 +13,9 @@ export class GitRemoteCommand extends Command {
       name: 'remote',
       type: 'project',
       groups: [MetadataGroup.PAID],
-      summary: 'Adds/updates the Ionic Appflow git remote to your local Ionic app',
+      summary: 'Adds/updates the Appflow git remote to your local Ionic app',
       description: `
-This command is used by ${input('ionic link')} when Ionic Appflow is used as the git host.
+This command is used by ${input('ionic link')} when Appflow is used as the git host.
 
 ${input('ionic git remote')} will check the local repository for whether or not the git remote is properly set up. This command operates on the ${strong('ionic')} remote. For advanced configuration, see ${strong('Settings')} => ${strong('Git')} in the app settings of the Dashboard[^dashboard].
       `,

--- a/packages/@ionic/cli/src/commands/link.ts
+++ b/packages/@ionic/cli/src/commands/link.ts
@@ -37,11 +37,11 @@ export class LinkCommand extends Command implements CommandPreRun {
       groups: [MetadataGroup.PAID],
       summary: 'Connect local apps to Ionic',
       description: `
-Link apps on Ionic Appflow to local Ionic projects with this command.
+Link apps on Appflow to local Ionic projects with this command.
 
-If the ${input('id')} argument is excluded, this command will prompt you to select an app from Ionic Appflow.
+If the ${input('id')} argument is excluded, this command will prompt you to select an app from Appflow.
 
-Ionic Appflow uses a git-based workflow to manage app updates. During the linking process, select ${strong('GitHub')} (recommended) or ${strong('Ionic Appflow')} as a git host. See our documentation[^appflow-git-basics] for more information.
+Appflow uses a git-based workflow to manage app updates. During the linking process, select ${strong('GitHub')} (recommended) or ${strong('Appflow')} as a git host. See our documentation[^appflow-git-basics] for more information.
 
 Ultimately, this command sets the ${strong('id')} property in ${strong(prettyPath(projectFile))}, which marks this app as linked.
 
@@ -62,7 +62,7 @@ If you are having issues linking, please get in touch with our Support[^support-
       inputs: [
         {
           name: 'id',
-          summary: `The Ionic Appflow ID of the app to link (e.g. ${input('a1b2c3d4')})`,
+          summary: `The Appflow ID of the app to link (e.g. ${input('a1b2c3d4')})`,
         },
       ],
       options: [

--- a/packages/@ionic/cli/src/commands/package/build.ts
+++ b/packages/@ionic/cli/src/commands/package/build.ts
@@ -71,7 +71,7 @@ export class BuildCommand extends Command {
       groups: [MetadataGroup.PAID],
       summary: 'Create a package build on Appflow',
       description: `
-This command creates a package build on Ionic Appflow. While the build is running, it prints the remote build log to the terminal. If the build is successful, it downloads the created app package file in the current directory. Downloading build artifacts can be skipped by supplying the flag ${input('skip-download')}.
+This command creates a package build on Appflow. While the build is running, it prints the remote build log to the terminal. If the build is successful, it downloads the created app package file in the current directory. Downloading build artifacts can be skipped by supplying the flag ${input('skip-download')}.
 
 Apart from ${input('--commit')}, every option can be specified using the full name setup within the Dashboard[^dashboard].
 

--- a/packages/@ionic/cli/src/commands/package/deploy.ts
+++ b/packages/@ionic/cli/src/commands/package/deploy.ts
@@ -52,7 +52,7 @@ export class DeployCommand extends Command {
       groups: [MetadataGroup.PAID],
       summary: 'Deploys a binary to a destination, such as an app store using Appflow',
       description: `
-This command deploys a binary to a destination using Ionic Appflow. While running, the remote log is printed to the terminal.
+This command deploys a binary to a destination using Appflow. While running, the remote log is printed to the terminal.
 
 The command takes two parameters: the numeric ID of the package build that previously created the binary and the name of the destination where the binary is going to be deployed.
 Both can be retrieved from the Dashboard[^dashboard].


### PR DESCRIPTION
[This PR](https://github.com/ionic-team/ionic-docs/pull/1840) on ionic-docs renamed Ionic Appflow to Appflow and one of the files is generated from the CLI, so generating CLI docs would overwrite the changes made.
So making changes here to match the file.