### PR TITLE
fix: add missing 'no-'s to command metadata

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/build.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/build.ts
@@ -20,13 +20,13 @@ export class BuildCommand extends CapacitorCommand implements CommandPreRun {
     const options: CommandMetadataOption[] = [
       // Build Options
       {
-        name: 'build',
+        name: 'no-build',
         summary: 'Do not invoke Ionic build',
         type: Boolean,
         default: true,
       },
       {
-        name: 'open',
+        name: 'no-open',
         summary: 'Do not invoke Capacitor open',
         type: Boolean,
         default: true,

--- a/packages/@ionic/cli/src/commands/capacitor/copy.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/copy.ts
@@ -9,7 +9,7 @@ export class CopyCommand extends CapacitorCommand implements CommandPreRun {
   async getMetadata(): Promise<CommandMetadata> {
     const options: CommandMetadataOption[] = [
       {
-        name: 'build',
+        name: 'no-build',
         summary: 'Do not invoke an Ionic build',
         type: Boolean,
         default: true,
@@ -51,7 +51,7 @@ ${input('ionic capacitor copy')} will do the following:
   }
 
   async run(inputs: CommandLineInputs, options: CommandLineOptions): Promise<void> {
-    const [ platform ] = inputs;
+    const [platform] = inputs;
 
     if (options.build) {
       await this.runBuild(inputs, options);

--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -59,7 +59,7 @@ export class RunCommand extends CapacitorCommand implements CommandPreRun {
       },
       // Build Options
       {
-        name: 'build',
+        name: 'no-build',
         summary: 'Do not invoke Ionic build',
         type: Boolean,
         default: true,

--- a/packages/@ionic/cli/src/commands/capacitor/sync.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/sync.ts
@@ -11,7 +11,7 @@ export class SyncCommand extends CapacitorCommand implements CommandPreRun {
   async getMetadata(): Promise<CommandMetadata> {
     const options: CommandMetadataOption[] = [
       {
-        name: 'build',
+        name: 'no-build',
         summary: 'Do not invoke an Ionic build',
         type: Boolean,
         default: true,

--- a/packages/@ionic/cli/src/commands/cordova/build.ts
+++ b/packages/@ionic/cli/src/commands/cordova/build.ts
@@ -13,7 +13,7 @@ export class BuildCommand extends CordovaCommand implements CommandPreRun {
     const options: CommandMetadataOption[] = [
       // Build Options
       {
-        name: 'build',
+        name: 'no-build',
         summary: 'Do not invoke an Ionic build',
         type: Boolean,
         default: true,

--- a/packages/@ionic/cli/src/commands/cordova/platform.ts
+++ b/packages/@ionic/cli/src/commands/cordova/platform.ts
@@ -30,7 +30,7 @@ Like running ${input('cordova platform')} directly, but adds default Ionic icons
       ],
       options: [
         {
-          name: 'resources',
+          name: 'no-resources',
           summary: `Do not pregenerate icons and splash screen resources (corresponds to ${input('add')})`,
           type: Boolean,
           default: true,
@@ -79,7 +79,7 @@ Like running ${input('cordova platform')} directly, but adds default Ionic icons
       throw new FatalException(`Cannot run ${input('ionic cordova platform')} outside a project directory.`);
     }
 
-    const [ action, platformName ] = inputs;
+    const [action, platformName] = inputs;
 
     const platforms = await getPlatforms(this.integration.root);
 

--- a/packages/@ionic/cli/src/commands/cordova/prepare.ts
+++ b/packages/@ionic/cli/src/commands/cordova/prepare.ts
@@ -11,7 +11,7 @@ export class PrepareCommand extends CordovaCommand implements CommandPreRun {
   async getMetadata(): Promise<CommandMetadata> {
     const options: CommandMetadataOption[] = [
       {
-        name: 'build',
+        name: 'no-build',
         summary: 'Do not invoke an Ionic build',
         type: Boolean,
         default: true,
@@ -62,7 +62,7 @@ You may wish to use ${input('ionic cordova prepare')} if you run your project wi
   async run(inputs: CommandLineInputs, options: CommandLineOptions): Promise<void> {
     const { loadCordovaConfig } = await import('../../lib/integrations/cordova/config');
     const { getPlatforms } = await import('../../lib/integrations/cordova/project');
-    const [ platform ] = inputs;
+    const [platform] = inputs;
 
     if (!this.project) {
       throw new FatalException(`Cannot run ${input('ionic cordova prepare')} outside a project directory.`);

--- a/packages/@ionic/cli/src/commands/cordova/run.ts
+++ b/packages/@ionic/cli/src/commands/cordova/run.ts
@@ -19,7 +19,7 @@ const debug = Debug('ionic:commands:run');
 
 const NATIVE_RUN_OPTIONS: readonly CommandMetadataOption[] = [
   {
-    name: 'native-run',
+    name: 'no-native-run',
     summary: `Do not use ${input('native-run')} to run the app; use Cordova instead`,
     type: Boolean,
     default: true,
@@ -61,7 +61,7 @@ export class RunCommand extends CordovaCommand implements CommandPreRun {
       },
       // Build Options
       {
-        name: 'build',
+        name: 'no-build',
         summary: 'Do not invoke Ionic build',
         type: Boolean,
         default: true,

--- a/packages/@ionic/cli/src/commands/serve.ts
+++ b/packages/@ionic/cli/src/commands/serve.ts
@@ -32,7 +32,7 @@ export class ServeCommand extends Command implements CommandPreRun {
         hint: weak('(--lab)'),
       },
       {
-        name: 'open',
+        name: 'no-open',
         summary: 'Do not open a browser window',
         type: Boolean,
         default: true,

--- a/packages/@ionic/cli/src/commands/start.ts
+++ b/packages/@ionic/cli/src/commands/start.ts
@@ -106,14 +106,14 @@ Use the ${input('--type')} option to start projects using older versions of Ioni
           type: Boolean,
         },
         {
-          name: 'deps',
+          name: 'no-deps',
           summary: 'Do not install npm/yarn dependencies',
           type: Boolean,
           default: true,
           groups: [MetadataGroup.ADVANCED],
         },
         {
-          name: 'git',
+          name: 'no-git',
           summary: 'Do not initialize a git repo',
           type: Boolean,
           default: true,


### PR DESCRIPTION
Some options are missing the "no-" part. I've added it in where it's missing.

Also wondering: where there are discrepancies between the docs and the help command, which is right? The docs don't contradict the help command, but they do include some options that are not present in the help command. I can go in and add these if helpful.