### PR TITLE
fix: support Capacitor 1 apps

### DIFF
--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -195,9 +195,16 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
     if (!output) {
       debug('Could not get config from Capacitor CLI (probably old version)');
       return;
+    } else {
+      try {
+        // Capacitor 1 returns the `command not found` error in stdout instead of stderror like in Capacitor 2
+        // This ensures that the output from the command is valid JSON to account for this
+        return JSON.parse(output);
+      } catch(e) {
+        debug('Could not get config from Capacitor CLI (probably old version)', e);
+        return;
+      }
     }
-
-    return JSON.parse(output);
   });
 
   getCapacitorConfig = lodash.memoize(async (): Promise<CapacitorConfig | undefined> => {


### PR DESCRIPTION
The Ionic CLI attempts to get the users Capacitor config with the `npx cap config --json` command that was introduced in Capacitor 3. This code assumes that if the command does not work then an output (stdout) would not be returned. This is the case with Capacitor 2 as it returns the "command not found" error to stderror. However, Capacitor 1 returns this to stdout which then causes an error because there is an output, but it not JSON and not parsable.