### PR TITLE
fix: Update superagent-proxy dependency to v3

### DIFF
--- a/packages/@ionic/cli/package.json
+++ b/packages/@ionic/cli/package.json
@@ -63,7 +63,7 @@
     "ssh-config": "^1.1.1",
     "stream-combiner2": "^1.1.1",
     "superagent": "^5.2.1",
-    "superagent-proxy": "^2.0.0",
+    "superagent-proxy": "^3.0.0",
     "tar": "^6.0.1",
     "tslib": "^2.0.1"
   },
@@ -79,7 +79,7 @@
     "@types/semver": "^7.1.0",
     "@types/split2": "^2.1.6",
     "@types/superagent": "^4.1.3",
-    "@types/superagent-proxy": "^2.0.0",
+    "@types/superagent-proxy": "^3.0.0",
     "@types/tar": "^4.0.0",
     "jest": "^26.4.2",
     "jest-cli": "^26.0.1",


### PR DESCRIPTION
**Change List**

This PR updates the dependency `superagent-proxy`, along with its type definitions from v2 to v3. There are [no breaking changes](https://github.com/TooTallNate/superagent-proxy/releases) in the dependency's APIs.

The current version relies on [`pac-resolver@4.2.0`](https://snyk.io/vuln/npm:pac-resolver), which has been reported to contain a remote code execution [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-23406).

This can also be observed on the results of `npm audit`.

```
# Create a new empty project
$ npm init a-new-project

# Add `@ionic/cli` as a dependency
$ npm install --save-dev @ionic/cli

added 212 packages, and audited 225 packages in 6s

26 packages are looking for funding
  run `npm fund` for details

5 high severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

# Listing the affected dependencies
$ npm ls pac-resolver --depth=4

a-new-project@1.0.0
└─┬ @ionic/cli@6.17.1
  └─┬ superagent-proxy@2.1.0
    └─┬ proxy-agent@4.0.1
      └─┬ pac-proxy-agent@4.1.0
        └── pac-resolver@4.2.0
```

Viewing the audit report
```
$ npm audit
# npm audit report

pac-resolver  <5.0.0
Severity: high
Code Injection in pac-resolver - https://github.com/advisories/GHSA-9j49-mfvp-vmhm
No fix available
node_modules/pac-resolver
  pac-proxy-agent  <=4.1.0
  Depends on vulnerable versions of pac-resolver
  node_modules/pac-proxy-agent
    proxy-agent  1.1.0 - 4.0.1
    Depends on vulnerable versions of pac-proxy-agent
    node_modules/proxy-agent
      superagent-proxy  0.4.0 - 2.1.0
      Depends on vulnerable versions of proxy-agent
      node_modules/superagent-proxy
        @ionic/cli  *
        Depends on vulnerable versions of superagent-proxy
        node_modules/@ionic/cli

5 high severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.
```