### PR TITLE
fix: bump cross-spawn version to avoid windows problem

### DIFF
--- a/packages/@ionic/utils-subprocess/package.json
+++ b/packages/@ionic/utils-subprocess/package.json
@@ -36,7 +36,7 @@
     "@ionic/utils-process": "2.1.8",
     "@ionic/utils-stream": "3.1.5",
     "@ionic/utils-terminal": "2.3.1",
-    "cross-spawn": "^7.0.0",
+    "cross-spawn": "^7.0.3",
     "debug": "^4.0.0",
     "tslib": "^2.0.1"
   },


### PR DESCRIPTION
There are some issues on windows on cross-spawn version < 7.0.3.
Despite the dependency has ^, make sure we force to at least 7.0.3 to make sure it's fixed