### PR TITLE
fix(#4575 #3989 #4707): ionic-lab set queries when also other than Angular

### DIFF
--- a/packages/@ionic/lab/src/stencil/components/ionlab-preview/ionlab-preview.tsx
+++ b/packages/@ionic/lab/src/stencil/components/ionlab-preview/ionlab-preview.tsx
@@ -18,13 +18,13 @@ export class Preview {
 
     const qp = {};
 
-    if (this.projectType === 'angular') {
+    if (this.projectType === 'ionic-angular') {
+      qp['ionicplatform'] = platform;
+      qp['ionicstatusbarpadding'] = 'true';
+    } else {
       qp['ionic:mode'] = platformMode(platform);
       qp['ionic:persistConfig'] = 'true';
       qp['ionic:_forceStatusbarPadding'] = 'true';
-    } else if (this.projectType === 'ionic-angular') {
-      qp['ionicplatform'] = platform;
-      qp['ionicstatusbarpadding'] = 'true';
     }
 
     return `${this.url}?${Object.keys(qp).map(k => `${encodeURIComponent(k)}=${encodeURIComponent(qp[k])}`).join('&')}`;


### PR DESCRIPTION
### Source issues
#4575 #3989 #4707

### Step for reproduce
```
ionic start test tabs --type vue
cd test
ionic serve --lab
```

### Screenshot
_Please don't care for title text was different following image, I found this bug when making my project._
![image](https://user-images.githubusercontent.com/1872507/151592648-67b99692-3751-454f-b05d-a7a71b4f6097.png)

### Set queries to app inside frame
![image](https://user-images.githubusercontent.com/1872507/151592682-213c0d46-003f-41d6-b0a4-650d2dfab57f.png)

### Checked behavior
* [x] Launch lab by `ionic-lab http://localhost:3000`

### Info
```

Ionic:

   Ionic CLI       : 6.18.1 (/home/angeart/dev/ionic-cli/packages/@ionic/cli)
   Ionic Framework : @ionic/vue 6.0.4

Capacitor:

   Capacitor CLI      : 3.4.0
   @capacitor/android : not installed
   @capacitor/core    : 3.4.0
   @capacitor/ios     : not installed

Utility:

   cordova-res : not installed globally
   native-run  : 1.5.0

System:

   NodeJS : v16.13.2 (/usr/local/bin/node)
   npm    : 8.1.2
   OS     : Linux 5.10

```
