### PR TITLE
(fix #4819) Allow ionic login to work in a non-interactive process

### DIFF
--- a/packages/@ionic/cli/src/commands/login.ts
+++ b/packages/@ionic/cli/src/commands/login.ts
@@ -160,7 +160,7 @@ If you are having issues logging in, please get in touch with our Support[^suppo
       await this.logout();
       await this.env.session.login(email, password);
     } else {
-      if (!this.env.flags.interactive) {
+      if (!this.env.flags.interactive && !this.env.flags.confirm) {
         throw new FatalException(
           'Refusing to attempt browser login in non-interactive mode.\n' +
           `If you are attempting to log in, make sure you are using a modern, interactive terminal. Otherwise, you can log in using inline username and password with ${input('ionic login <email> <password>')}. See ${input('ionic login --help')} for more details.`
@@ -170,12 +170,15 @@ If you are having issues logging in, please get in touch with our Support[^suppo
       this.env.log.info(`During this process, a browser window will open to authenticate you. Please leave this process running until authentication is complete.`);
       this.env.log.nl();
 
-      const login = await this.env.prompt({
-        type: 'confirm',
-        name: 'continue',
-        message: 'Open the browser to log in to your Ionic account?',
-        default: true,
-      });
+      let login = true;
+      if (!this.env.flags.confirm) {
+        login = await this.env.prompt({
+          type: 'confirm',
+          name: 'continue',
+          message: 'Open the browser to log in to your Ionic account?',
+          default: true,
+        });
+      }
 
       if (login) {
         await this.logout();

--- a/packages/@ionic/cli/src/commands/login.ts
+++ b/packages/@ionic/cli/src/commands/login.ts
@@ -170,15 +170,12 @@ If you are having issues logging in, please get in touch with our Support[^suppo
       this.env.log.info(`During this process, a browser window will open to authenticate you. Please leave this process running until authentication is complete.`);
       this.env.log.nl();
 
-      let login = true;
-      if (!this.env.flags.confirm) {
-        login = await this.env.prompt({
-          type: 'confirm',
-          name: 'continue',
-          message: 'Open the browser to log in to your Ionic account?',
-          default: true,
-        });
-      }
+      const login = await this.env.prompt({
+        type: 'confirm',
+        name: 'continue',
+        message: 'Open the browser to log in to your Ionic account?',
+        default: true,
+      });
 
       if (login) {
         await this.logout();


### PR DESCRIPTION
Allow ionic login to work in a non-interactive process. This could be done using the --confirm flag which should "Turn off interactive prompts"