### PR TITLE
feat(integrations): add ng add cordova-builder

### DIFF
--- a/packages/@ionic/cli/src/lib/integrations/cordova/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/cordova/index.ts
@@ -120,6 +120,14 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
       },
     });
     await super.add(details);
+    if(this.e.project.type === 'angular'){
+      try {
+      const integration = this.e.project.requireIntegration(this.name);
+      await this.e.shell.run('ng', ['add', '@ionic/cordova-builders', '--skip-confirmation'], {cwd: integration.root});
+      } catch (e) {
+        debug('Error while adding @ionic/cordova-builders.');
+      }
+    }
   }
 
   async getCordovaConfig(): Promise<configlib.CordovaConfig | undefined> {

--- a/packages/@ionic/cli/src/lib/integrations/cordova/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/cordova/index.ts
@@ -125,7 +125,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
         const integration = this.e.project.requireIntegration(this.name);
         await this.e.shell.run('ng', ['add', '@ionic/cordova-builders', '--skip-confirmation'], { cwd: integration.root });
       } catch (e) {
-        debug('Error while adding @ionic/cordova-builders.');
+        debug('Error while adding @ionic/cordova-builders: %O', e);
       }
     }
   }

--- a/packages/@ionic/cli/src/lib/integrations/cordova/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/cordova/index.ts
@@ -120,7 +120,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
       },
     });
     await super.add(details);
-    if(this.e.project.type === 'angular'){
+    if (this.e.project.type === 'angular') {
       try {
         const integration = this.e.project.requireIntegration(this.name);
         await this.e.shell.run('ng', ['add', '@ionic/cordova-builders', '--skip-confirmation'], { cwd: integration.root });

--- a/packages/@ionic/cli/src/lib/integrations/cordova/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/cordova/index.ts
@@ -122,8 +122,8 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
     await super.add(details);
     if(this.e.project.type === 'angular'){
       try {
-      const integration = this.e.project.requireIntegration(this.name);
-      await this.e.shell.run('ng', ['add', '@ionic/cordova-builders', '--skip-confirmation'], {cwd: integration.root});
+        const integration = this.e.project.requireIntegration(this.name);
+        await this.e.shell.run('ng', ['add', '@ionic/cordova-builders', '--skip-confirmation'], { cwd: integration.root });
       } catch (e) {
         debug('Error while adding @ionic/cordova-builders.');
       }


### PR DESCRIPTION
This modifies the Cordova integration to run `ng add @ionic/cordova-builders` for angular projects.

For new Ionic projects, we have removed the old Cordova builders in favor of moving forward with Capacitor.

For legacy projects, this will add back the builders for Angular app and install the necessary dependencies.   