### PR TITLE
fix(capacitor): Match platform version with CLI version

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -273,7 +273,7 @@ export abstract class CapacitorCommand extends Command {
     }
 
     if (semver.gte(version, '3.0.0-alpha.1')) {
-      const [ manager, ...managerArgs ] = await pkgManagerArgs(this.env.config.get('npmClient'), { command: 'install', pkg: `@capacitor/${platform}@latest`, saveDev: false });
+      const [ manager, ...managerArgs ] = await pkgManagerArgs(this.env.config.get('npmClient'), { command: 'install', pkg: `@capacitor/${platform}@${version}`, saveDev: false });
       await this.env.shell.run(manager, managerArgs, { cwd: this.integration.root });
     }
 


### PR DESCRIPTION
Since Capacitor CLI/core are installed on app creation, if a new minor release is launched in between the app was created and the platforms were added, it will fail to install "latest" because of npm 7 peer dependencies.
This PR changes the install command to match the installed Capacitor CLI version instead of using latest.

closes https://github.com/ionic-team/ionic-cli/issues/4822
closes https://github.com/ionic-team/ionic-cli/issues/4786