### PR TITLE
remove deprecated @types packages

### DIFF
--- a/packages/@ionic/cli/package.json
+++ b/packages/@ionic/cli/package.json
@@ -74,8 +74,6 @@
     "@types/jest": "^26.0.10",
     "@types/lodash": "^4.14.104",
     "@types/node": "~10.17.13",
-    "@types/open": "~6.2.1",
-    "@types/os-name": "^3.1.0",
     "@types/semver": "^7.1.0",
     "@types/split2": "^2.1.6",
     "@types/superagent": "4.1.3",


### PR DESCRIPTION
open and os-name have built-in typescript support, no longer need to use the @types packages