### PR TITLE
chore: move re-exported types to dependencies

### DIFF
--- a/packages/@ionic/utils-fs/package.json
+++ b/packages/@ionic/utils-fs/package.json
@@ -31,13 +31,13 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@types/fs-extra": "^8.0.0",
     "debug": "^4.0.0",
     "fs-extra": "^9.0.0",
     "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",
-    "@types/fs-extra": "^8.0.0",
     "@types/jest": "^26.0.10",
     "@types/node": "~10.17.13",
     "jest": "^26.4.2",

--- a/packages/@ionic/utils-terminal/package.json
+++ b/packages/@ionic/utils-terminal/package.json
@@ -31,6 +31,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@types/slice-ansi": "^4.0.0",
     "debug": "^4.0.0",
     "signal-exit": "^3.0.3",
     "slice-ansi": "^4.0.0",
@@ -45,7 +46,6 @@
     "@types/jest": "^26.0.10",
     "@types/node": "~10.17.13",
     "@types/signal-exit": "^3.0.0",
-    "@types/slice-ansi": "^4.0.0",
     "@types/wrap-ansi": "^3.0.0",
     "jest": "^26.4.2",
     "jest-cli": "^26.0.1",


### PR DESCRIPTION
fs-extra and slice-ansi are being re exported by utils-fs and utils-terminal, that causes problems if other packages are installing those packages and they don't have the corresponding types packages installed.
Moving the equivalent @types packages from devDependencies to dependencies solves the issue.