### PR TITLE
fix(integrations): Move ng add @ionic/cordova-builders after install

### DIFF
--- a/packages/@ionic/cli/src/commands/start.ts
+++ b/packages/@ionic/cli/src/commands/start.ts
@@ -646,9 +646,20 @@ Use the ${input('--type')} option to start projects using older versions of Ioni
 
       const [installer, ...installerArgs] = await pkgManagerArgs(this.env.config.get('npmClient'), { command: 'install' });
       await this.env.shell.run(installer, installerArgs, shellOptions);
+
+      if (options['cordova']) {
+        try {
+          await this.env.shell.run('ng', ['add', '@ionic/cordova-builders', '--skip-confirmation'], { cwd: this.project.rootDirectory });
+        } catch (e) {
+          debug('Error while adding @ionic/cordova-builders: %O', e);
+        }
+      }
     } else {
       // --no-deps flag was used so skip installing dependencies, this also results in the package.json being out sync with the package.json so warn the user
       this.env.log.warn('Using the --no-deps flag results in an out of date package lock file. The lock file can be updated by performing an `install` with your package manager.');
+      if (options['cordova']) {
+        this.env.log.warn('@ionic/cordova-builders couldn\'t be added, make sure you run `ng add @ionic/cordova-builders` after performing an `install` with your package manager.');
+      }
     }
 
     if (!this.schema.cloned) {

--- a/packages/@ionic/cli/src/lib/integrations/cordova/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/cordova/index.ts
@@ -120,14 +120,6 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
       },
     });
     await super.add(details);
-    if (this.e.project.type === 'angular') {
-      try {
-        const integration = this.e.project.requireIntegration(this.name);
-        await this.e.shell.run('ng', ['add', '@ionic/cordova-builders', '--skip-confirmation'], { cwd: integration.root });
-      } catch (e) {
-        debug('Error while adding @ionic/cordova-builders: %O', e);
-      }
-    }
   }
 
   async getCordovaConfig(): Promise<configlib.CordovaConfig | undefined> {


### PR DESCRIPTION
closes https://github.com/ionic-team/ionic-cli/issues/4850

Running `ng add @ionic/cordova-builders` on add will fail if ng command (angular CLI) is not globally installed.

This PR moves the `ng add @ionic/cordova-builders` after the packages are installed so ng command is available

If --no-deps is passed it will warn that users have to run the command themselves since it won't install the packages and ng won't be available.

The code doesn't check if the type is angular since there is code that runs before the new code that will set cordova option to false if the type is not angular since cordova is not supported for other project types.