### PR TITLE
feat(cli): allow cap electron commands

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -134,6 +134,11 @@ export abstract class CapacitorCommand extends Command {
     }
   });
 
+  isCorePlatform(platform: string): boolean {
+    const platforms = ['android', 'ios'];
+    return platforms.includes(platform);
+  }
+
   async getInstalledPlatforms(): Promise<string[]> {
     const cli = await this.getCapacitorCLIConfig();
     const androidPlatformDirAbs = cli?.android.platformDirAbs ?? path.resolve(this.integration.root, 'android');
@@ -146,6 +151,10 @@ export abstract class CapacitorCommand extends Command {
 
     if (await pathExists(iosPlatformDirAbs)) {
       platforms.push('ios');
+    }
+
+    if (await pathExists(path.resolve(this.integration.root, 'electron'))) {
+      platforms.push('electron');
     }
 
     return platforms;
@@ -297,8 +306,10 @@ export abstract class CapacitorCommand extends Command {
     }
 
     if (semver.gte(version, '3.0.0-alpha.1')) {
-      const [ manager, ...managerArgs ] = await pkgManagerArgs(this.env.config.get('npmClient'), { command: 'install', pkg: `@capacitor/${platform}@${version}`, saveDev: false });
-      await this.env.shell.run(manager, managerArgs, { cwd: this.integration.root });
+      if (this.isCorePlatform(platform)) {
+        const [ manager, ...managerArgs ] = await pkgManagerArgs(this.env.config.get('npmClient'), { command: 'install', pkg: `@capacitor/${platform}@${version}`, saveDev: false });
+        await this.env.shell.run(manager, managerArgs, { cwd: this.integration.root });
+      }
     }
 
     await this.runCapacitor(['add', platform]);


### PR DESCRIPTION
Since electron is now a community platform, when `ionic cap add electron` command is run, ionic CLI will try to install @capacitor/electron 3.x, which no longer exists.

This PR will change the install behaviour to only install core platforms.
It will also add electron to the installed platforms array so users can use ionic cap electron command (if not on the array the command is still forwarded to capacitor CLI, but shows an ugly error, this prevents the error)

Reference https://forum.ionicframework.com/t/no-matching-version-found-for-capacitor-electron-3-5-1/223508

Alternatives:
The CLI could install @capacitor-community/electron@latest if `ionic cap add electron` command is run
The CLI could error if electron or other community platforms are used with `ionic cap` command with a message that indicates that those platforms are not supported by ionic CLI and they should use the capacitor commands without ionic "prefix", instead of forwarding them to capacitor CLI
