### PR TITLE
chore(docs): deprecate ionic docs command

### DIFF
--- a/packages/@ionic/cli/package.json
+++ b/packages/@ionic/cli/package.json
@@ -78,7 +78,7 @@
     "@types/split2": "^2.1.6",
     "@types/superagent": "4.1.3",
     "@types/superagent-proxy": "^3.0.0",
-    "@types/tar": "^4.0.0",
+    "@types/tar": "^6.1.2",
     "jest": "^26.4.2",
     "jest-cli": "^26.0.1",
     "lint-staged": "^10.0.2",

--- a/packages/@ionic/cli/package.json
+++ b/packages/@ionic/cli/package.json
@@ -78,7 +78,7 @@
     "@types/split2": "^2.1.6",
     "@types/superagent": "4.1.3",
     "@types/superagent-proxy": "^3.0.0",
-    "@types/tar": "^6.1.2",
+    "@types/tar": "^4.0.0",
     "jest": "^26.4.2",
     "jest-cli": "^26.0.1",
     "lint-staged": "^10.0.2",

--- a/packages/@ionic/cli/src/commands/docs.ts
+++ b/packages/@ionic/cli/src/commands/docs.ts
@@ -31,7 +31,7 @@ export class DocsCommand extends Command {
     const homepage = 'https://ion.link/docs';
     const url = this.project ? await this.project.getDocsUrl() : homepage;
 
-    this.env.log.warn(`The "ionic docs" command has been deprecated and will be removed in an upcoming major release of the Ionic CLI. Developers should bookmark ${url} in their browser for easy access.`);
+    this.env.log.warn(`The ${input('ionic docs')} command has been deprecated and will be removed in an upcoming major release of the Ionic CLI. Developers should bookmark ${url} in their browser for easy access.`);
 
     try {
       const { req } = await createRequest('HEAD', url, this.env.config.getHTTPConfig());

--- a/packages/@ionic/cli/src/commands/docs.ts
+++ b/packages/@ionic/cli/src/commands/docs.ts
@@ -31,6 +31,8 @@ export class DocsCommand extends Command {
     const homepage = 'https://ion.link/docs';
     const url = this.project ? await this.project.getDocsUrl() : homepage;
 
+    this.env.log.warn(`The "ionic docs" command has been deprecated and will be removed in an upcoming major release of the Ionic CLI. Developers should bookmark ${url} in their browser for easy access.`);
+
     try {
       const { req } = await createRequest('HEAD', url, this.env.config.getHTTPConfig());
       await req;


### PR DESCRIPTION
The `ionic docs` command has been deprecated and will be removed in an upcoming major release of the Ionic CLI.

The recommended alternative is to bookmark the Ionic Docs website in your browser.