### PR TITLE
chore(deps): update @types/tar

### DIFF
--- a/packages/@ionic/cli/package.json
+++ b/packages/@ionic/cli/package.json
@@ -78,7 +78,7 @@
     "@types/split2": "^2.1.6",
     "@types/superagent": "4.1.3",
     "@types/superagent-proxy": "^3.0.0",
-    "@types/tar": "^4.0.0",
+    "@types/tar": "^6.1.2",
     "jest": "^26.4.2",
     "jest-cli": "^26.0.1",
     "lint-staged": "^10.0.2",


### PR DESCRIPTION
The following error is logged when running `npm run build`:

```
../../../node_modules/@types/tar/index.d.ts:12:27 - error TS7016: Could not find a declaration file for module 'minipass'. '/home/runner/work/ionic-cli/ionic-cli/node_modules/minipass/index.js' implicitly has an 'any' type.
  Try `npm install @types/minipass` if it exists or add a new declaration (.d.ts) file containing `declare module 'minipass';`

12 import MiniPass = require('minipass');
                             ~~~~~~~~~~
```

This appears to be due to a version mismatch between `tar` and `@types/tar`.