### PR TITLE
chore(doctor): deprecate ionic doctor command

### DIFF
--- a/packages/@ionic/cli/src/commands/doctor/base.ts
+++ b/packages/@ionic/cli/src/commands/doctor/base.ts
@@ -15,7 +15,7 @@ export abstract class DoctorCommand extends Command {
       throw new FatalException(`Cannot use ${input('ionic doctor')} outside a project directory.`);
     }
 
-    this.env.log.warn(`The "ionic doctor" command has been deprecated and will be removed in an upcoming major release of the Ionic CLI. Developers can safely remove any references to this command as many of the checks are no longer needed.`);
+    this.env.log.warn(`The ${input('ionic doctor')} command has been deprecated and will be removed in an upcoming major release of the Ionic CLI. Developers can safely remove any references to this command as many of the checks are no longer needed.`);
 
     const { AilmentRegistry } = await import('../../lib/doctor');
 

--- a/packages/@ionic/cli/src/commands/doctor/base.ts
+++ b/packages/@ionic/cli/src/commands/doctor/base.ts
@@ -15,6 +15,8 @@ export abstract class DoctorCommand extends Command {
       throw new FatalException(`Cannot use ${input('ionic doctor')} outside a project directory.`);
     }
 
+    this.env.log.warn(`The "ionic doctor" command has been deprecated and will be removed in an upcoming major release of the Ionic CLI. Developers can safely remove any references to this command as many of the checks are no longer needed.`);
+
     const { AilmentRegistry } = await import('../../lib/doctor');
 
     const registry = new AilmentRegistry();

--- a/packages/@ionic/cli/src/commands/doctor/base.ts
+++ b/packages/@ionic/cli/src/commands/doctor/base.ts
@@ -15,8 +15,6 @@ export abstract class DoctorCommand extends Command {
       throw new FatalException(`Cannot use ${input('ionic doctor')} outside a project directory.`);
     }
 
-    this.env.log.warn(`The ${input('ionic doctor')} command has been deprecated and will be removed in an upcoming major release of the Ionic CLI. Developers can safely remove any references to this command as many of the checks are no longer needed.`);
-
     const { AilmentRegistry } = await import('../../lib/doctor');
 
     const registry = new AilmentRegistry();
@@ -31,6 +29,8 @@ export abstract class DoctorCommand extends Command {
 
     const tasks = this.createTaskChain();
     const isLoggedIn = this.env.session.isLoggedIn();
+
+    this.env.log.warn(`The ${input('ionic doctor')} command has been deprecated and will be removed in an upcoming major release of the Ionic CLI. Developers can safely remove any references to this command as many of the checks are no longer needed.`);
 
     if (!isLoggedIn) {
       this.env.log.warn(`For best results, please make sure you're logged in to Ionic.\nSome issues can't be detected without authentication. Run:\n\n    ${input('ionic login')}`);


### PR DESCRIPTION
This PR deprecates the `ionic doctor` command. The table below lists the current checks and the recommended alternatives:

| check | alternative |
| ------ | ---------- | 
| `npm` is installed locally | Developers should audit their projects to ensure `npm` is not installed locally. |
| `@ionic/cli` is installed locally | Developers should audit their projects to ensure the Ionic CLI is not installed locally. |
| git is not being used | While we recommend using version control, the final decision should be left up to the developer. |
| An app is linked with an app on Appflow, but the configuration is invalid. | Appflow has been moved to a separate CLI. |
| Old Ionic Native packages are installed | [Ionic Native is now managed by the community as `awesome-cordova-plugins`](https://ionicframework.com/blog/a-new-chapter-for-ionic-native/) |
| `viewport-fit=cover` is not set in `index.html` | All Ionic apps have shipped with the viewport meta tag pre-configured for several years now. |
| The default package ID is used in `config.xml` | Developers should audit their projects to ensure the default package ID is not used. |
| The `platforms/` directory for Cordova was committed | Developers should audit their projects to ensure the `platforms/` directory is not committed. |
| There are unsaved Cordova platforms | Developers should audit their projects to ensure Cordova platforms are being added and saved properly. |
