### PR TITLE
fix(cli): capacitor config not being read from multi-project directories

### DIFF
--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -195,7 +195,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
       return new Promise((resolve, reject) => {
         exec(cmd, opts, (error, stdout, stderr) => {
           if (error) {
-            resolve(undefined);
+            reject();
           }
           resolve(stdout);
         })

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -191,8 +191,6 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
 
     debug('Getting config with Capacitor CLI: %O', args);
 
-    //const output = await this.e.shell.cmdinfo('capacitor', args, { cwd: this.root });
-
     const output = await ((cmd: string, opts: ExecOptions): Promise<string | undefined> => {
       return new Promise((resolve, reject) => {
         exec(cmd, opts, (error, stdout, stderr) => {

--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -1,3 +1,4 @@
+import { exec, ExecOptions } from 'child_process';
 import { parseArgs } from '@ionic/cli-framework';
 import { mkdirp, pathExists } from '@ionic/utils-fs';
 import { prettyPath } from '@ionic/utils-terminal';
@@ -190,7 +191,18 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
 
     debug('Getting config with Capacitor CLI: %O', args);
 
-    const output = await this.e.shell.cmdinfo('capacitor', args, { cwd: this.root });
+    //const output = await this.e.shell.cmdinfo('capacitor', args, { cwd: this.root });
+
+    const output = await ((cmd: string, opts: ExecOptions): Promise<string | undefined> => {
+      return new Promise((resolve, reject) => {
+        exec(cmd, opts, (error, stdout, stderr) => {
+          if (error) {
+            resolve(undefined);
+          }
+          resolve(stdout);
+        })
+      })
+    })(`capacitor ${args.join(' ')}`, { cwd: this.root });
 
     if (!output) {
       debug('Could not get config from Capacitor CLI (probably old version)');

--- a/packages/@ionic/lab/package.json
+++ b/packages/@ionic/lab/package.json
@@ -44,13 +44,14 @@
     "@ionic/cli-framework": "5.1.3",
     "@ionic/utils-fs": "3.1.6",
     "chalk": "^4.0.0",
-    "express": "^4.16.2",
+    "express": "4.16.2",
     "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@ionic-internal/ionic-ds": "^2.1.0",
     "@stencil/core": "~1.8.5",
-    "@types/express": "^4.11.0",
+    "@types/express": "4.11.0",
+    "@types/express-serve-static-core": "4.11.0",
     "@types/node": "~10.17.13",
     "lint-staged": "^10.0.2",
     "rimraf": "^3.0.0",

--- a/packages/@ionic/v1-toolkit/package.json
+++ b/packages/@ionic/v1-toolkit/package.json
@@ -42,7 +42,7 @@
     "chalk": "^4.0.0",
     "chokidar": "^3.0.1",
     "debug": "^4.0.0",
-    "express": "^4.16.2",
+    "express": "4.16.2",
     "gulp": "^4.0.2",
     "http-proxy-middleware": "^0.20.0",
     "tiny-lr": "^1.1.0",
@@ -51,7 +51,8 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.1",
-    "@types/express": "^4.11.0",
+    "@types/express": "4.11.0",
+    "@types/express-serve-static-core": "4.11.0",
     "@types/gulp": "^4.0.6",
     "@types/http-proxy-middleware": "^0.19.0",
     "@types/jest": "^26.0.10",


### PR DESCRIPTION
This PR fixes the `capacitor` commands not being able to read the `capacitor.config` files in the correct project directory leading to errors when detecting things like platforms being already installed.

A release of `6.20.2-testing.0` is available on npm under the `testing` tag for testing this fix.

---
Closes #4903