### PR TITLE
Inline Source Maps

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/copy.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/copy.ts
@@ -17,9 +17,9 @@ export class CopyCommand extends CapacitorCommand implements CommandPreRun {
       },
       {
         name: 'inline',
-        summary: 'Use inline source maps (only available on capacitor 4.2.0)',
+        summary: 'Use inline source maps (only available on capacitor 4.2.0+)',
         type: Boolean,
-        default: true
+        default: false
       }
     ];
 

--- a/packages/@ionic/cli/src/commands/capacitor/copy.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/copy.ts
@@ -4,6 +4,7 @@ import { CommandInstanceInfo, CommandLineInputs, CommandLineOptions, CommandMeta
 import { input } from '../../lib/color';
 
 import { CapacitorCommand } from './base';
+import * as semver from "semver";
 
 export class CopyCommand extends CapacitorCommand implements CommandPreRun {
   async getMetadata(): Promise<CommandMetadata> {
@@ -14,6 +15,12 @@ export class CopyCommand extends CapacitorCommand implements CommandPreRun {
         type: Boolean,
         default: true,
       },
+      {
+        name: 'inline',
+        summary: 'Use inline source maps (only available on capacitor 4.2.0)',
+        type: Boolean,
+        default: true
+      }
     ];
 
     const runner = this.project && await this.project.getBuildRunner();
@@ -58,6 +65,11 @@ ${input('ionic capacitor copy')} will do the following:
     }
 
     const args = ['copy'];
+
+    const capVersion = await this.getCapacitorVersion();
+    if(semver.gte(capVersion, "4.2.0") && options.inline) {
+      args.push("--inline")
+    }
 
     if (platform) {
       args.push(platform);

--- a/packages/@ionic/cli/src/commands/capacitor/sync.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/sync.ts
@@ -6,6 +6,7 @@ import { FatalException } from '../../lib/errors';
 import { Hook, HookDeps } from '../../lib/hooks';
 
 import { CapacitorCommand } from './base';
+import * as semver from 'semver';
 
 export class SyncCommand extends CapacitorCommand implements CommandPreRun {
   async getMetadata(): Promise<CommandMetadata> {
@@ -16,6 +17,12 @@ export class SyncCommand extends CapacitorCommand implements CommandPreRun {
         type: Boolean,
         default: true,
       },
+      {
+        name: 'inline',
+        summary: 'Use inline source maps  (only available on capacitor 4.1.0)',
+        type: Boolean,
+        default: true
+      }
     ];
 
     const runner = this.project && await this.project.getBuildRunner();
@@ -66,6 +73,11 @@ ${input('ionic capacitor sync')} will do the following:
     }
 
     const args = ['sync'];
+
+    const capVersion = await this.getCapacitorVersion();
+    if(semver.gte(capVersion, "4.1.0") && options.inline) {
+      args.push("--inline")
+    }
 
     if (platform) {
       args.push(platform);

--- a/packages/@ionic/cli/src/commands/capacitor/sync.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/sync.ts
@@ -19,9 +19,9 @@ export class SyncCommand extends CapacitorCommand implements CommandPreRun {
       },
       {
         name: 'inline',
-        summary: 'Use inline source maps  (only available on capacitor 4.1.0)',
+        summary: 'Use inline source maps  (only available on capacitor 4.1.0+)',
         type: Boolean,
-        default: true
+        default: false
       }
     ];
 


### PR DESCRIPTION
since @capacitor/cli 4.2.0 the --inline option is available to avoid .js.map files. This is necessary to debug typescript code on Android

closes #3802