### PR TITLE
fix(capacitor): Error if no emulators or devices are found on run

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -205,12 +205,16 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
             );
           }
         } else {
-          options['target'] = await this.env.prompt({
-            type: 'list',
-            name: 'target',
-            message: 'Which device would you like to target?',
-            choices: targets.map(t => ({ name: `${t.name} (${t.id})`, value: t.id })),
-          });
+          if (targets.length > 0) {
+            options['target'] = await this.env.prompt({
+              type: 'list',
+              name: 'target',
+              message: 'Which device would you like to target?',
+              choices: targets.map(t => ({ name: `${t.name} (${t.id})`, value: t.id })),
+            });
+          } else {
+            throw new FatalException(`No devices or emulators found`);
+          }
 
           if (!inputs[0]) {
             throw new FatalException(`The ${input('platform')} argument is required.`);


### PR DESCRIPTION
Ionic CLI shows a prompt to pick devices even if no devices are found.
This is fixed in Capacitor CLI if running from there, but was still a problem if running using ionic capacitor run command

closes https://github.com/ionic-team/capacitor/issues/6056