### PR TITLE
fix: catch deploy manifest error if no capacitor CLI

### DIFF
--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -227,11 +227,14 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
   });
 
   getCapacitorConfig = lodash.memoize(async (): Promise<CapacitorConfig | undefined> => {
-    const cli = await this.getCapacitorCLIConfig();
-
-    if (cli) {
-      debug('Loaded Capacitor config!');
-      return cli.app.extConfig;
+    try {
+      const cli = await this.getCapacitorCLIConfig();
+      if (cli) {
+        debug('Loaded Capacitor config!');
+        return cli.app.extConfig;
+      }
+    } catch (ex) {
+      // ignore
     }
 
     // fallback to reading capacitor.config.json if it exists


### PR DESCRIPTION
`ionic deploy manifest` command is failing on latest release because of `capacitor config` command returning an error when Capacitor CLI is not installed.
This change allows to fallback to reading the capacitor.config.json if no Capacitor CLI is installed as it did in previous versions.

The CLI stills errors if you try to run `ionic capacitor` commands, this just prevents the error on `ionic deploy manifest`.

Change available as @ionic/cli@6.20.7-testing.0 on testing tag 