### PR TITLE
fix(cli): Deprecate doctor and lab commands

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/build.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/build.ts
@@ -36,17 +36,17 @@ export class BuildCommand extends CapacitorCommand implements CommandPreRun {
     const footnotes: Footnote[] = [
       {
         id: 'capacitor-native-config-docs',
-        url: 'https://capacitor.ionicframework.com/docs/basics/configuring-your-app',
+        url: 'https://capacitorjs.com/docs/basics/configuring-your-app',
         shortUrl: 'https://ion.link/capacitor-native-config-docs',
       },
       {
         id: 'capacitor-ios-config-docs',
-        url: 'https://capacitor.ionicframework.com/docs/ios/configuration',
+        url: 'https://capacitorjs.com/docs/ios/configuration',
         shortUrl: 'https://ion.link/capacitor-ios-config-docs',
       },
       {
         id: 'capacitor-android-config-docs',
-        url: 'https://capacitor.ionicframework.com/docs/android/configuration',
+        url: 'https://capacitorjs.com/docs/android/configuration',
         shortUrl: 'https://ion.link/capacitor-android-config-docs',
       },
     ];

--- a/packages/@ionic/cli/src/commands/doctor/check.ts
+++ b/packages/@ionic/cli/src/commands/doctor/check.ts
@@ -1,4 +1,4 @@
-import { contains, validate } from '@ionic/cli-framework';
+import { contains, MetadataGroup, validate } from '@ionic/cli-framework';
 
 import { CommandLineInputs, CommandLineOptions, CommandMetadata, IAilment } from '../../definitions';
 import { isTreatableAilment } from '../../guards';
@@ -13,6 +13,7 @@ export class DoctorCheckCommand extends DoctorCommand {
       name: 'check',
       type: 'project',
       summary: 'Check the health of your Ionic project',
+      groups: [MetadataGroup.DEPRECATED],
       description: `
 This command detects and prints common issues and suggested steps to fix them.
 

--- a/packages/@ionic/cli/src/commands/doctor/list.ts
+++ b/packages/@ionic/cli/src/commands/doctor/list.ts
@@ -1,3 +1,4 @@
+import { MetadataGroup } from '@ionic/cli-framework';
 import { strcmp } from '@ionic/cli-framework/utils/string';
 import { columnar } from '@ionic/utils-terminal';
 
@@ -14,6 +15,7 @@ export class DoctorListCommand extends DoctorCommand {
       name: 'list',
       type: 'project',
       summary: 'List all issues and their identifiers',
+      groups: [MetadataGroup.DEPRECATED],
       description: `
 Issues can have various tags:
 - ${strong('treatable')}: ${input('ionic doctor treat')} can attempt to fix the issue

--- a/packages/@ionic/cli/src/commands/doctor/treat.ts
+++ b/packages/@ionic/cli/src/commands/doctor/treat.ts
@@ -1,4 +1,4 @@
-import { contains, validate } from '@ionic/cli-framework';
+import { contains, MetadataGroup, validate } from '@ionic/cli-framework';
 
 import { CommandLineInputs, CommandLineOptions, CommandMetadata, TreatableAilment } from '../../definitions';
 import { isExitCodeException, isTreatableAilment } from '../../guards';
@@ -16,6 +16,7 @@ export class DoctorTreatCommand extends DoctorCommand {
       name: 'treat',
       type: 'project',
       summary: 'Attempt to fix issues in your Ionic project',
+      groups: [MetadataGroup.DEPRECATED],
       description: `
 This command detects and attempts to fix common issues. Before a fix is attempted, the steps are printed and a confirmation prompt is displayed.
 

--- a/packages/@ionic/cli/src/commands/serve.ts
+++ b/packages/@ionic/cli/src/commands/serve.ts
@@ -27,7 +27,7 @@ export class ServeCommand extends Command implements CommandPreRun {
         name: 'lab-port',
         summary: 'Use specific port for Ionic Lab server',
         default: DEFAULT_LAB_PORT.toString(),
-        groups: [MetadataGroup.ADVANCED, MetadataGroup.HIDDEN],
+        groups: [MetadataGroup.HIDDEN, MetadataGroup.ADVANCED],
         spec: { value: 'port' },
         hint: weak('(--lab)'),
       },

--- a/packages/@ionic/cli/src/commands/serve.ts
+++ b/packages/@ionic/cli/src/commands/serve.ts
@@ -19,7 +19,7 @@ export class ServeCommand extends Command implements CommandPreRun {
         name: 'lab-host',
         summary: 'Use specific host for Ionic Lab server',
         default: 'localhost',
-        groups: [MetadataGroup.ADVANCED],
+        groups: [MetadataGroup.HIDDEN, MetadataGroup.ADVANCED],
         spec: { value: 'host' },
         hint: weak('(--lab)'),
       },
@@ -27,7 +27,7 @@ export class ServeCommand extends Command implements CommandPreRun {
         name: 'lab-port',
         summary: 'Use specific port for Ionic Lab server',
         default: DEFAULT_LAB_PORT.toString(),
-        groups: [MetadataGroup.ADVANCED],
+        groups: [MetadataGroup.ADVANCED, MetadataGroup.HIDDEN],
         spec: { value: 'port' },
         hint: weak('(--lab)'),
       },
@@ -56,10 +56,11 @@ export class ServeCommand extends Command implements CommandPreRun {
         summary: 'Test your apps on multiple platform types in the browser',
         type: Boolean,
         aliases: ['l'],
+        groups: [MetadataGroup.HIDDEN],
       },
     ];
 
-    const exampleCommands = ['', '--external', '--lab'];
+    const exampleCommands = ['', '--external'];
     const footnotes: Footnote[] = [];
 
     let description = `

--- a/packages/@ionic/cli/src/lib/project/angular/build.ts
+++ b/packages/@ionic/cli/src/lib/project/angular/build.ts
@@ -10,7 +10,7 @@ const NG_BUILD_OPTIONS = [
   {
     name: 'configuration',
     aliases: ['c'],
-    summary: 'Specify the configuration to use.',
+    summary: 'Specify the configuration to use',
     type: String,
     groups: [MetadataGroup.ADVANCED, 'cordova'],
     hint: weak('[ng]'),

--- a/packages/@ionic/cli/src/lib/project/index.ts
+++ b/packages/@ionic/cli/src/lib/project/index.ts
@@ -557,7 +557,7 @@ export abstract class Project implements IProject {
       } else {
         throw new FatalException(
           `The ${input('webDir')} property must be set in the Capacitor configuration file. \n` +
-          `See the Capacitor docs for more information: ${strong('https://capacitor.ionicframework.com/docs/basics/configuring-your-app')}`
+          `See the Capacitor docs for more information: ${strong('https://capacitorjs.com/docs/basics/configuring-your-app')}`
         );
       }
     } else {


### PR DESCRIPTION
Deprecate doctor and lab commands. Also fix the URLs that were modified in the generated Ionic Docs cli.json but not at their source here.