### PR TITLE
fix(cli): native solution preview should no longer be hidden

### DIFF
--- a/packages/@ionic/cli/assets/oauth/success/index.html
+++ b/packages/@ionic/cli/assets/oauth/success/index.html
@@ -87,13 +87,13 @@
       font-weight: 400;
     }
 
-    .ad-box{
+    .native-solutions{
       display:block;
       text-align:center;
       padding-top:30px;
     }
 
-    .ad-box>ion-card{
+    .native-solutions>ion-card{
       width:300px;
       display:inline-block;
     }
@@ -125,7 +125,7 @@
         <h1 class="errortext1" style="display:none;">There was an error logging in. Please return to the terminal.</h1>
         <p class="errortext2" style="display:none;">In the meantime, check out our Native Solutions.</p>
 
-        <div class="ad-box">
+        <div class="native-solutions">
           <ion-card>
             <ion-card-content>
               <svg width="123" height="24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M35.28 6.64h-1.94V18h1.94V6.64zm7.8 4.14a3.07 3.07 0 00-2.65-1.28c-2.45 0-3.84 1.97-3.84 4.36 0 2.36 1.4 4.33 3.84 4.33 1.3 0 2.27-.51 2.8-1.37V18H45V6h-1.9v4.78zm.09 3.08c0 1.48-.88 2.65-2.34 2.65-1.44 0-2.33-1.17-2.33-2.65 0-1.52.9-2.68 2.33-2.68 1.46 0 2.34 1.16 2.34 2.68zm11.15.54l.01-.6c0-2.42-1.61-4.3-4.08-4.3-2.46 0-4.13 1.92-4.13 4.34 0 2.48 1.64 4.35 4.15 4.35 1.93 0 3.4-1.17 3.9-2.81h-1.92c-.3.73-1.05 1.18-1.93 1.18-1.33 0-2.18-.85-2.32-2.16h6.32zm-4.07-3.34c1.23 0 2.03.78 2.2 1.93h-4.42c.2-1.13 1-1.93 2.22-1.93zM57.2 9.7h-1.76V18h1.9v-4.82c0-1.3.75-2.04 1.95-2.04 1.14 0 1.65.75 1.65 1.88V18h1.9v-5.22c0-1.93-1.07-3.28-3.08-3.28-1.36 0-2.21.64-2.56 1.3V9.7zm9.44 1.52h1.4V9.7h-1.4V7.54h-1.9V9.7h-1.26v1.52h1.26V18h1.9v-6.78zm3-2.92c.7 0 1.19-.48 1.19-1.16 0-.7-.5-1.2-1.18-1.2-.7 0-1.2.5-1.2 1.2 0 .68.5 1.16 1.2 1.16zM68.7 18h1.9V9.7h-1.9V18zm5.77-6.78h1.39V9.7h-1.4V7.54h-1.9V9.7H71.3v1.52h1.26V18h1.9v-6.78zm2.9 10.1h1.9L83.98 9.7H82l-2.28 6.01-2.26-6.01h-2.03l3.34 8.24-1.4 3.39zm18-14.68l-3.24 8.8h-.03l-3.22-8.8h-2.19L91.06 18h2.02l4.4-11.36h-2.13zm7.94 3.07v1.19c-.53-.87-1.5-1.38-2.8-1.38-2.45 0-3.84 1.97-3.84 4.34 0 2.36 1.4 4.33 3.84 4.33 1.3 0 2.27-.51 2.8-1.37V18h1.76V9.71h-1.76zm-4.73 4.15c0-1.5.9-2.66 2.33-2.66 1.46 0 2.34 1.17 2.34 2.66 0 1.48-.88 2.65-2.34 2.65-1.44 0-2.33-1.17-2.33-2.65zm11.74 2.65c-1.16 0-1.77-.64-1.77-1.93V9.7h-1.9v4.78c0 2.13.98 3.71 3.67 3.71 2.68 0 3.66-1.58 3.66-3.71V9.7h-1.9v4.88c0 1.3-.61 1.93-1.76 1.93zm7.14 1.49V6h-1.9v12h1.9zm3.87-6.78h1.4V9.7h-1.4V7.54h-1.9V9.7h-1.27v1.52h1.27V18h1.9v-6.78z" fill="#001A3A"></path><path d="M24 12c0 5.25-.9 8.32-3.07 10.05C19.05 23.55 16.13 24 12 24c-4.72 0-7.8-.6-9.68-2.7C.68 19.5 0 16.57 0 12c0-4.88.75-7.88 2.63-9.6C4.5.52 7.5 0 12 0c4.43 0 7.43.53 9.3 2.33C23.25 4.04 24 7.04 24 12z" fill="#0065D4"></path><path d="M12 20.03a7.95 7.95 0 01-7.95-7.95 7.95 7.95 0 0115.9.07c0 4.43-3.6 7.88-7.95 7.88zM12 5.1a7.04 7.04 0 10-.02 14.08A7.04 7.04 0 0012 5.1z" fill="#1F95FF"></path><path d="M11.17 11.33V3.68c0-.45.38-.83.83-.83.45 0 .82.38.82.83v7.65c0 .45-.37.82-.82.82a.83.83 0 01-.83-.82z" fill="url(#subnav-logo_svg__paint0_linear)"></path><path d="M19.65 15.68l-7.27-4.2a.85.85 0 00-1.13.3c-.22.37-.07.82.3 1.05l7.28 4.2c.37.22.9.07 1.12-.3.23-.3.08-.83-.3-1.05z" fill="url(#subnav-logo_svg__paint1_linear)"></path><path d="M4.35 15.68l7.28-4.2a.85.85 0 011.12.3c.22.37.07.82-.3 1.05l-7.28 4.2a.85.85 0 01-1.12-.3c-.23-.3-.08-.83.3-1.05z" fill="url(#subnav-logo_svg__paint2_linear)"></path><path d="M12 8.48a3.68 3.68 0 10.01 7.36A3.68 3.68 0 0012 8.48z" fill="#fff"></path><defs><linearGradient id="subnav-logo_svg__paint0_linear" x1="12" y1="8.81" x2="12" y2="3.04" gradientUnits="userSpaceOnUse"><stop stop-color="#80BDFE"></stop><stop offset="1" stop-color="#DFF1FB"></stop></linearGradient><linearGradient id="subnav-logo_svg__paint1_linear" x1="14.95" y1="13.88" x2="19.94" y2="16.77" gradientUnits="userSpaceOnUse"><stop stop-color="#80BDFE"></stop><stop offset="1" stop-color="#DFF1FB"></stop></linearGradient><linearGradient id="subnav-logo_svg__paint2_linear" x1="9.02" y1="13.91" x2="4.03" y2="16.71" gradientUnits="userSpaceOnUse"><stop stop-color="#80BDFE"></stop><stop offset="1" stop-color="#DFF1FB"></stop></linearGradient></defs></svg>


### PR DESCRIPTION
The CSS class used for the Native Solutions preview was triggering a popular ad blocker.
Before:
![image](https://user-images.githubusercontent.com/11831150/224809306-61d65ecd-4a28-41e3-8a19-38de7b708869.png)
After:
![image](https://user-images.githubusercontent.com/11831150/224809183-d530fb34-6f7e-4fcb-9c04-5760726759ee.png)
