### PR TITLE
feat(): add vite support for react and vue

### DIFF
--- a/packages/@ionic/cli/src/constants.ts
+++ b/packages/@ionic/cli/src/constants.ts
@@ -7,7 +7,7 @@ import { ProjectType } from './definitions';
 export const ASSETS_DIRECTORY = path.resolve(__dirname, 'assets');
 
 export const PROJECT_FILE = process.env['IONIC_CONFIG_FILE'] ?? 'ionic.config.json';
-export const PROJECT_TYPES: ProjectType[] = ['angular', 'react', 'vue', 'ionic-angular', 'ionic1', 'custom'];
+export const PROJECT_TYPES: ProjectType[] = ['angular', 'react', 'vue', 'ionic-angular', 'ionic1', 'custom', 'vue-vite', 'react-vite'];
 export const LEGACY_PROJECT_TYPES: ProjectType[] = ['ionic-angular', 'ionic1'];
 export const MODERN_PROJECT_TYPES: ProjectType[] = lodash.difference(PROJECT_TYPES, LEGACY_PROJECT_TYPES);
 

--- a/packages/@ionic/cli/src/definitions.ts
+++ b/packages/@ionic/cli/src/definitions.ts
@@ -78,7 +78,7 @@ export interface Runner<T extends object, U> {
   run(options: T): Promise<U>;
 }
 
-export type ProjectType = 'angular' | 'ionic-angular' | 'ionic1' | 'custom' | 'bare' | 'react' | 'vue';
+export type ProjectType = 'angular' | 'ionic-angular' | 'ionic1' | 'custom' | 'bare' | 'react' | 'vue' | 'react-vite' | 'vue-vite';
 export type HookName = 'build:before' | 'build:after' | 'serve:before' | 'serve:after' | 'capacitor:run:before' | 'capacitor:build:before' | 'capacitor:sync:after';
 
 export type CapacitorRunHookName = 'capacitor:run:before';

--- a/packages/@ionic/cli/src/lib/project/index.ts
+++ b/packages/@ionic/cli/src/lib/project/index.ts
@@ -307,6 +307,12 @@ export async function createProjectFromDetails(details: ProjectDetailsResult, de
     case 'vue':
       const { VueProject } = await import('./vue');
       return new VueProject(details, deps);
+    case 'vue-vite':
+      const { VueViteProject } = await import('./vue-vite');
+      return new VueViteProject(details, deps);
+    case 'react-vite':
+      const { ReactViteProject } = await import('./react-vite');
+      return new ReactViteProject(details, deps);
     case 'custom':
       const { CustomProject } = await import('./custom');
       return new CustomProject(details, deps);

--- a/packages/@ionic/cli/src/lib/project/react-vite/build.ts
+++ b/packages/@ionic/cli/src/lib/project/react-vite/build.ts
@@ -25,8 +25,8 @@ export class ReactViteBuildRunner extends BuildRunner<ReactBuildOptions> {
   }
 
   async buildProject(options: ReactBuildOptions): Promise<void> {
-    const vueScripts = new ReactViteBuildCLI(this.e);
-    await vueScripts.build(options);
+    const reactVite = new ReactViteBuildCLI(this.e);
+    await reactVite.build(options);
   }
 }
 

--- a/packages/@ionic/cli/src/lib/project/react-vite/build.ts
+++ b/packages/@ionic/cli/src/lib/project/react-vite/build.ts
@@ -1,0 +1,55 @@
+import { CommandLineInputs, CommandLineOptions, CommandMetadata, ReactBuildOptions } from '../../../definitions';
+import { BUILD_SCRIPT, BuildCLI, BuildRunner, BuildRunnerDeps } from '../../build';
+
+import { ReactViteProject } from './';
+
+export interface ReactViteBuildRunnerDeps extends BuildRunnerDeps {
+  readonly project: ReactViteProject;
+}
+export class ReactViteBuildRunner extends BuildRunner<ReactBuildOptions> {
+  constructor(protected readonly e: ReactViteBuildRunnerDeps) {
+    super();
+  }
+
+  async getCommandMetadata(): Promise<Partial<CommandMetadata>> {
+    return {};
+  }
+
+  createOptionsFromCommandLine(inputs: CommandLineInputs, options: CommandLineOptions): ReactBuildOptions {
+    const baseOptions = super.createBaseOptionsFromCommandLine(inputs, options);
+
+    return {
+      ...baseOptions,
+      type: 'react',
+    };
+  }
+
+  async buildProject(options: ReactBuildOptions): Promise<void> {
+    const vueScripts = new ReactViteBuildCLI(this.e);
+    await vueScripts.build(options);
+  }
+}
+
+export class ReactViteBuildCLI extends BuildCLI<ReactBuildOptions> {
+  readonly name = 'Vite CLI Service';
+  readonly pkg = 'vite';
+  readonly program = 'vite';
+  readonly prefix = 'vite';
+  readonly script = BUILD_SCRIPT;
+
+  protected async buildArgs(options: ReactBuildOptions): Promise<string[]> {
+    const { pkgManagerArgs } = await import('../../utils/npm');
+
+    if (this.resolvedProgram === this.program) {
+      return ['build', ...(options['--'] || [])];
+    } else {
+      const [ , ...pkgArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'run', script: this.script, scriptArgs: options['--'] });
+      return pkgArgs;
+    }
+  }
+
+  protected async buildEnvVars(options: ReactBuildOptions): Promise<NodeJS.ProcessEnv> {
+    const env: NodeJS.ProcessEnv = {};
+    return { ...await super.buildEnvVars(options), ...env };
+  }
+}

--- a/packages/@ionic/cli/src/lib/project/react-vite/index.ts
+++ b/packages/@ionic/cli/src/lib/project/react-vite/index.ts
@@ -7,7 +7,7 @@ import { Project } from '../';
 import { InfoItem } from '../../../definitions';
 import { RunnerNotFoundException } from '../../errors';
 
-const debug = Debug('ionic:lib:project:vue');
+const debug = Debug('ionic:lib:project:react');
 
 export class ReactViteProject extends Project {
   readonly type: 'react' = 'react';
@@ -32,7 +32,7 @@ export class ReactViteProject extends Project {
   }
 
   /**
-   * We can't detect Vue project types. We don't know what they look like!
+   * We can't detect React project types. We don't know what they look like!
    */
   async detected() {
     try {

--- a/packages/@ionic/cli/src/lib/project/react-vite/index.ts
+++ b/packages/@ionic/cli/src/lib/project/react-vite/index.ts
@@ -1,0 +1,80 @@
+import * as chalk from 'chalk';
+import * as Debug from 'debug';
+import * as lodash from 'lodash';
+import * as path from 'path';
+
+import { Project } from '../';
+import { InfoItem } from '../../../definitions';
+import { RunnerNotFoundException } from '../../errors';
+
+const debug = Debug('ionic:lib:project:vue');
+
+export class ReactViteProject extends Project {
+  readonly type: 'react' = 'react';
+
+  async getInfo(): Promise<InfoItem[]> {
+    const [
+      [ionicReact, ionicReactPath],
+    ] = await Promise.all([
+      this.getPackageJson('@ionic/react'),
+    ]);
+
+    return [
+      ...(await super.getInfo()),
+      {
+        group: 'ionic',
+        name: 'Ionic Framework',
+        key: 'framework',
+        value: ionicReact ? `@ionic/react ${ionicReact.version}` : 'not installed',
+        path: ionicReactPath,
+      },
+    ];
+  }
+
+  /**
+   * We can't detect Vue project types. We don't know what they look like!
+   */
+  async detected() {
+    try {
+      const pkg = await this.requirePackageJson();
+      const deps = lodash.assign({}, pkg.dependencies, pkg.devDependencies);
+
+      if (typeof deps['@ionic/react'] === 'string') {
+        debug(`${chalk.bold('@ionic/react')} detected in ${chalk.bold('package.json')}`);
+        return true;
+      }
+    } catch (e) {
+      // ignore
+    }
+
+    return false;
+  }
+
+  async getDefaultDistDir(): Promise<string> {
+    return 'dist';
+  }
+
+  async requireBuildRunner(): Promise<import('./build').ReactViteBuildRunner> {
+    const { ReactViteBuildRunner } = await import('./build');
+    const deps = { ...this.e, project: this };
+    return new ReactViteBuildRunner(deps);
+  }
+
+  async requireServeRunner(): Promise<import('./serve').ReactViteServeRunner> {
+    const { ReactViteServeRunner } = await import('./serve');
+    const deps = { ...this.e, project: this };
+    return new ReactViteServeRunner(deps);
+  }
+
+  async requireGenerateRunner(): Promise<never> {
+    throw new RunnerNotFoundException(
+      `Cannot perform generate for React projects.\n` +
+      `Since you're using the ${chalk.bold('React')} project type, this command won't work. The Ionic CLI doesn't know how to generate framework components for React projects.`
+    );
+  }
+
+  setPrimaryTheme(themeColor: string): Promise<void> {
+    const themePath = path.join(this.directory, 'src', 'theme', 'variables.css');
+    return this.writeThemeColor(themePath, themeColor);
+  }
+}

--- a/packages/@ionic/cli/src/lib/project/react-vite/serve.ts
+++ b/packages/@ionic/cli/src/lib/project/react-vite/serve.ts
@@ -1,0 +1,152 @@
+import { ParsedArgs, unparseArgs } from '@ionic/cli-framework';
+import { stripAnsi } from '@ionic/cli-framework-output';
+import { findClosestOpenPort } from '@ionic/utils-network';
+import { CommandMetadata, ServeDetails, ReactServeOptions, } from '../../../definitions';
+
+import { strong } from '../../color';
+import { BIND_ALL_ADDRESS, DEFAULT_ADDRESS, LOCAL_ADDRESSES, SERVE_SCRIPT, ServeCLI, ServeRunner, ServeRunnerDeps, } from '../../serve';
+
+export class ReactViteServeRunner extends ServeRunner<ReactServeOptions> {
+  constructor(protected readonly e: ServeRunnerDeps) {
+    super();
+  }
+
+  async getCommandMetadata(): Promise<Partial<CommandMetadata>> {
+    return {};
+  }
+
+  modifyOpenUrl(url: string, _options: ReactServeOptions): string {
+    return url;
+  }
+
+  async serveProject(options: ReactServeOptions): Promise<ServeDetails> {
+    const [externalIP, availableInterfaces] = await this.selectExternalIP(options);
+
+    const port = (options.port = await findClosestOpenPort(options.port));
+
+    const reactScripts = new ReactViteServeCLI(this.e);
+    await reactScripts.serve(options);
+
+    return {
+      custom: reactScripts.resolvedProgram !== reactScripts.program,
+      protocol: options.https ? 'https' : 'http',
+      localAddress: 'localhost',
+      externalAddress: externalIP,
+      externalNetworkInterfaces: availableInterfaces,
+      port,
+      externallyAccessible: ![BIND_ALL_ADDRESS, ...LOCAL_ADDRESSES].includes(
+        externalIP
+      ),
+    };
+  }
+}
+
+export class ReactViteServeCLI extends ServeCLI<ReactServeOptions> {
+  readonly name = 'Vite CLI Service';
+  readonly pkg = 'vite';
+  readonly program = 'vite';
+  readonly prefix = 'vite';
+  readonly script = SERVE_SCRIPT;
+  protected chunks = 0;
+
+  async serve(options: ReactServeOptions): Promise<void> {
+    this.on('compile', (chunks) => {
+      if (chunks > 0) {
+        this.e.log.info(
+          `... and ${strong(chunks.toString())} additional chunks`
+        );
+      }
+    });
+
+    return super.serve(options);
+  }
+
+  protected stdoutFilter(line: string): boolean {
+    if (this.resolvedProgram !== this.program) {
+      return super.stdoutFilter(line);
+    }
+    const strippedLine = stripAnsi(line);
+    const compileMsgs = [
+      'Compiled successfully',
+      'Compiled with warnings',
+      'Failed to compile',
+      "ready in"
+    ];
+    if (compileMsgs.some((msg) => strippedLine.includes(msg))) {
+      this.emit('ready');
+      return false;
+    }
+
+    if (strippedLine.match(/.*chunk\s{\d+}.+/)) {
+      this.chunks++;
+      return false;
+    }
+
+    if (strippedLine.includes('Compiled successfully')) {
+      this.emit('compile', this.chunks);
+      this.chunks = 0;
+    }
+
+    if(strippedLine.includes('has unexpectedly closed')) {
+       return false;
+    }
+    return true;
+  }
+
+  protected stderrFilter(line: string): boolean {
+    if (this.resolvedProgram !== this.program) {
+      return super.stderrFilter(line);
+    }
+    const strippedLine = stripAnsi(line);
+    if (strippedLine.includes('webpack.Progress')) {
+      return false;
+    }
+    if(strippedLine.includes('has unexpectedly closed')) {
+       return false;
+    }
+
+    return true;
+  }
+
+  protected async buildArgs(options: ReactServeOptions): Promise<string[]> {
+    const args: ParsedArgs = {
+      _: [],
+      host: options.host,
+      port: options.port ? options.port.toString() : undefined,
+    };
+    const { pkgManagerArgs } = await import('../../utils/npm');
+
+    const separatedArgs = options['--'];
+
+    if (this.resolvedProgram === this.program) {
+      return [...unparseArgs(args), ...separatedArgs];
+    } else {
+      const [, ...pkgArgs] = await pkgManagerArgs(
+        this.e.config.get('npmClient'),
+        {
+          command: 'run',
+          script: this.script,
+          scriptArgs: [...unparseArgs(args), ...separatedArgs],
+        }
+      );
+      return pkgArgs;
+    }
+  }
+
+  protected async buildEnvVars(
+    options: ReactServeOptions
+  ): Promise<NodeJS.ProcessEnv> {
+    const env: NodeJS.ProcessEnv = {};
+    // // Vue CLI binds to `localhost` by default, but if specified it prints a
+    // // warning, so don't set `HOST` if the host is set to `localhost`.
+    if (options.host !== DEFAULT_ADDRESS) {
+      env.HOST = options.host;
+    }
+
+    env.PORT = String(options.port);
+
+    env.HTTPS = options.https ? 'true' : 'false';
+
+    return { ...(await super.buildEnvVars(options)), ...env };
+  }
+}

--- a/packages/@ionic/cli/src/lib/project/react-vite/serve.ts
+++ b/packages/@ionic/cli/src/lib/project/react-vite/serve.ts
@@ -137,7 +137,7 @@ export class ReactViteServeCLI extends ServeCLI<ReactServeOptions> {
     options: ReactServeOptions
   ): Promise<NodeJS.ProcessEnv> {
     const env: NodeJS.ProcessEnv = {};
-    // // Vue CLI binds to `localhost` by default, but if specified it prints a
+    // // Vite binds to `localhost` by default, but if specified it prints a
     // // warning, so don't set `HOST` if the host is set to `localhost`.
     if (options.host !== DEFAULT_ADDRESS) {
       env.HOST = options.host;

--- a/packages/@ionic/cli/src/lib/project/vue-vite/build.ts
+++ b/packages/@ionic/cli/src/lib/project/vue-vite/build.ts
@@ -1,0 +1,55 @@
+import { CommandLineInputs, CommandLineOptions, CommandMetadata, VueBuildOptions } from '../../../definitions';
+import { BUILD_SCRIPT, BuildCLI, BuildRunner, BuildRunnerDeps } from '../../build';
+
+import { VueViteProject } from './';
+
+export interface VueBuildRunnerDeps extends BuildRunnerDeps {
+  readonly project: VueViteProject;
+}
+export class VueViteBuildRunner extends BuildRunner<VueBuildOptions> {
+  constructor(protected readonly e: VueBuildRunnerDeps) {
+    super();
+  }
+
+  async getCommandMetadata(): Promise<Partial<CommandMetadata>> {
+    return {};
+  }
+
+  createOptionsFromCommandLine(inputs: CommandLineInputs, options: CommandLineOptions): VueBuildOptions {
+    const baseOptions = super.createBaseOptionsFromCommandLine(inputs, options);
+
+    return {
+      ...baseOptions,
+      type: 'vue',
+    };
+  }
+
+  async buildProject(options: VueBuildOptions): Promise<void> {
+    const vueScripts = new VueViteBuildCLI(this.e);
+    await vueScripts.build(options);
+  }
+}
+
+export class VueViteBuildCLI extends BuildCLI<VueBuildOptions> {
+  readonly name = 'Vite CLI Service';
+  readonly pkg = 'vite';
+  readonly program = 'vite';
+  readonly prefix = 'vite';
+  readonly script = BUILD_SCRIPT;
+
+  protected async buildArgs(options: VueBuildOptions): Promise<string[]> {
+    const { pkgManagerArgs } = await import('../../utils/npm');
+
+    if (this.resolvedProgram === this.program) {
+      return ['build', ...(options['--'] || [])];
+    } else {
+      const [ , ...pkgArgs ] = await pkgManagerArgs(this.e.config.get('npmClient'), { command: 'run', script: this.script, scriptArgs: options['--'] });
+      return pkgArgs;
+    }
+  }
+
+  protected async buildEnvVars(options: VueBuildOptions): Promise<NodeJS.ProcessEnv> {
+    const env: NodeJS.ProcessEnv = {};
+    return { ...await super.buildEnvVars(options), ...env };
+  }
+}

--- a/packages/@ionic/cli/src/lib/project/vue-vite/index.ts
+++ b/packages/@ionic/cli/src/lib/project/vue-vite/index.ts
@@ -1,0 +1,80 @@
+import * as chalk from 'chalk';
+import * as Debug from 'debug';
+import * as lodash from 'lodash';
+import * as path from 'path';
+
+import { Project } from '../';
+import { InfoItem } from '../../../definitions';
+import { RunnerNotFoundException } from '../../errors';
+
+const debug = Debug('ionic:lib:project:vue');
+
+export class VueViteProject extends Project {
+  readonly type: 'vue' = 'vue';
+
+  async getInfo(): Promise<InfoItem[]> {
+    const [
+      [ionicVuePkg, ionicVuePkgPath],
+    ] = await Promise.all([
+      this.getPackageJson('@ionic/vue'),
+    ]);
+
+    return [
+      ...(await super.getInfo()),
+      {
+        group: 'ionic',
+        name: 'Ionic Framework',
+        key: 'framework',
+        value: ionicVuePkg ? `@ionic/vue ${ionicVuePkg.version}` : 'not installed',
+        path: ionicVuePkgPath,
+      },
+    ];
+  }
+
+  /**
+   * We can't detect Vue project types. We don't know what they look like!
+   */
+  async detected() {
+    try {
+      const pkg = await this.requirePackageJson();
+      const deps = lodash.assign({}, pkg.dependencies, pkg.devDependencies);
+
+      if (typeof deps['@ionic/vue'] === 'string') {
+        debug(`${chalk.bold('@ionic/vue')} detected in ${chalk.bold('package.json')}`);
+        return true;
+      }
+    } catch (e) {
+      // ignore
+    }
+
+    return false;
+  }
+
+  async getDefaultDistDir(): Promise<string> {
+    return 'dist';
+  }
+
+  async requireBuildRunner(): Promise<import('./build').VueViteBuildRunner> {
+    const { VueViteBuildRunner } = await import('./build');
+    const deps = { ...this.e, project: this };
+    return new VueViteBuildRunner(deps);
+  }
+
+  async requireServeRunner(): Promise<import('./serve').VueServeRunner> {
+    const { VueServeRunner } = await import('./serve');
+    const deps = { ...this.e, project: this };
+    return new VueServeRunner(deps);
+  }
+
+  async requireGenerateRunner(): Promise<never> {
+    throw new RunnerNotFoundException(
+      `Cannot perform generate for Vue projects.\n` +
+      `Since you're using the ${chalk.bold('Vue')} project type, this command won't work. The Ionic CLI doesn't know how to generate framework components for Vue projects.`
+    );
+  }
+
+  setPrimaryTheme(themeColor: string): Promise<void> {
+    const themePath = path.join(this.directory, 'src', 'theme', 'variables.css');
+    return this.writeThemeColor(themePath, themeColor);
+  }
+}

--- a/packages/@ionic/cli/src/lib/project/vue-vite/serve.ts
+++ b/packages/@ionic/cli/src/lib/project/vue-vite/serve.ts
@@ -1,0 +1,159 @@
+import { ParsedArgs, unparseArgs } from '@ionic/cli-framework';
+import { stripAnsi } from '@ionic/cli-framework-output';
+import { findClosestOpenPort } from '@ionic/utils-network';
+
+import {
+  CommandMetadata,
+  ServeDetails,
+  VueServeOptions,
+} from '../../../definitions';
+import { strong } from '../../color';
+import {
+  BIND_ALL_ADDRESS,
+  DEFAULT_ADDRESS,
+  LOCAL_ADDRESSES,
+  SERVE_SCRIPT,
+  ServeCLI,
+  ServeRunner,
+  ServeRunnerDeps,
+} from '../../serve';
+
+export class VueServeRunner extends ServeRunner<VueServeOptions> {
+  constructor(protected readonly e: ServeRunnerDeps) {
+    super();
+  }
+
+  async getCommandMetadata(): Promise<Partial<CommandMetadata>> {
+    return {};
+  }
+
+  modifyOpenUrl(url: string, _options: VueServeOptions): string {
+    return url;
+  }
+
+  async serveProject(options: VueServeOptions): Promise<ServeDetails> {
+    const [externalIP, availableInterfaces] = await this.selectExternalIP(
+      options
+    );
+
+    const port = (options.port = await findClosestOpenPort(options.port));
+
+    const vueScripts = new VueViteServeCLI(this.e);
+    await vueScripts.serve(options);
+
+    return {
+      custom: vueScripts.resolvedProgram !== vueScripts.program,
+      protocol: options.https ? 'https' : 'http',
+      localAddress: 'localhost',
+      externalAddress: externalIP,
+      externalNetworkInterfaces: availableInterfaces,
+      port,
+      externallyAccessible: ![BIND_ALL_ADDRESS, ...LOCAL_ADDRESSES].includes(
+        externalIP
+      ),
+    };
+  }
+}
+
+export class VueViteServeCLI extends ServeCLI<VueServeOptions> {
+  readonly name = 'Vite CLI Service';
+  readonly pkg = 'vite';
+  readonly program = 'vite';
+  readonly prefix = 'vite';
+  readonly script = SERVE_SCRIPT;
+  protected chunks = 0;
+
+  async serve(options: VueServeOptions): Promise<void> {
+    this.on('compile', (chunks) => {
+      if (chunks > 0) {
+        this.e.log.info(
+          `... and ${strong(chunks.toString())} additional chunks`
+        );
+      }
+    });
+
+    return super.serve(options);
+  }
+
+  protected stdoutFilter(line: string): boolean {
+    if (this.resolvedProgram !== this.program) {
+      return super.stdoutFilter(line);
+    }
+    const strippedLine = stripAnsi(line);
+    const compileMsgs = [
+      'Compiled successfully',
+      'Compiled with warnings',
+      'Failed to compile',
+      "ready in"
+    ];
+    if (compileMsgs.some((msg) => strippedLine.includes(msg))) {
+      this.emit('ready');
+      return false;
+    }
+
+    if (strippedLine.match(/.*chunk\s{\d+}.+/)) {
+      this.chunks++;
+      return false;
+    }
+
+    if (strippedLine.includes('Compiled successfully')) {
+      this.emit('compile', this.chunks);
+      this.chunks = 0;
+    }
+
+    return true;
+  }
+  protected stderrFilter(line: string): boolean {
+    if (this.resolvedProgram !== this.program) {
+      return super.stderrFilter(line);
+    }
+    const strippedLine = stripAnsi(line);
+    if (strippedLine.includes('webpack.Progress')) {
+      return false;
+    }
+
+    return true;
+  }
+
+  protected async buildArgs(options: VueServeOptions): Promise<string[]> {
+    const args: ParsedArgs = {
+      _: [],
+      host: options.host,
+      port: options.port ? options.port.toString() : undefined,
+    };
+    const { pkgManagerArgs } = await import('../../utils/npm');
+
+    const separatedArgs = options['--'];
+
+    if (this.resolvedProgram === this.program) {
+      return [...unparseArgs(args), ...separatedArgs];
+    } else {
+      const [, ...pkgArgs] = await pkgManagerArgs(
+        this.e.config.get('npmClient'),
+        {
+          command: 'run',
+          script: this.script,
+          scriptArgs: [...unparseArgs(args), ...separatedArgs],
+        }
+      );
+      return pkgArgs;
+    }
+  }
+
+  protected async buildEnvVars(
+    options: VueServeOptions
+  ): Promise<NodeJS.ProcessEnv> {
+    const env: NodeJS.ProcessEnv = {};
+    // // Vue CLI binds to `localhost` by default, but if specified it prints a
+    // // warning, so don't set `HOST` if the host is set to `localhost`.
+    if (options.host !== DEFAULT_ADDRESS) {
+      env.HOST = options.host;
+    }
+
+    env.PORT = String(options.port);
+
+    env.HTTPS = options.https ? 'true' : 'false';
+
+    return { ...(await super.buildEnvVars(options)), ...env };
+  }
+}


### PR DESCRIPTION
This adds two additional project types, vue-vite and react-vite. This is to support the plan for migrating the react and vue stater projects to vite while also maintaining backwards compat for older react-scripts based projects and vue-cli based projects.