### PR TITLE
feat(): use vite specific projects for starters

### DIFF
--- a/packages/@ionic/cli/src/lib/start.ts
+++ b/packages/@ionic/cli/src/lib/start.ts
@@ -213,28 +213,28 @@ export const STARTER_TEMPLATES: StarterTemplate[] = [
     projectType: 'vue',
     type: 'managed',
     description: 'A starting project with a simple tabbed interface',
-    id: 'vue-official-tabs',
+    id: 'vue-vite-official-tabs',
   },
   {
     name: 'sidemenu',
     projectType: 'vue',
     type: 'managed',
     description: 'A starting project with a side menu with navigation in the content area',
-    id: 'vue-official-sidemenu',
+    id: 'vue-vite-official-sidemenu',
   },
   {
     name: 'blank',
     projectType: 'vue',
     type: 'managed',
     description: 'A blank starter project',
-    id: 'vue-official-blank',
+    id: 'vue-vite-official-blank',
   },
   {
     name: 'list',
     projectType: 'vue',
     type: 'managed',
     description: 'A starting project with a list',
-    id: 'vue-official-list',
+    id: 'vue-vite-official-list',
   },
   // Angular
   {
@@ -278,14 +278,14 @@ export const STARTER_TEMPLATES: StarterTemplate[] = [
     projectType: 'react',
     type: 'managed',
     description: 'A blank starter project',
-    id: 'react-official-blank',
+    id: 'react-vite-official-blank',
   },
   {
     name: 'list',
     projectType: 'react',
     type: 'managed',
     description: 'A starting project with a list',
-    id: 'react-official-list',
+    id: 'react-vite-official-list',
   },
   {
     name: 'my-first-app',
@@ -299,14 +299,14 @@ export const STARTER_TEMPLATES: StarterTemplate[] = [
     projectType: 'react',
     type: 'managed',
     description: 'A starting project with a side menu with navigation in the content area',
-    id: 'react-official-sidemenu',
+    id: 'react-vite-official-sidemenu',
   },
   {
     name: 'tabs',
     projectType: 'react',
     type: 'managed',
     description: 'A starting project with a simple tabbed interface',
-    id: 'react-official-tabs',
+    id: 'react-vite-official-tabs',
   },
   // Old Ionic V3
   {


### PR DESCRIPTION
See https://github.com/ionic-team/starters/pull/1763.

For V7 of the CLI, we want to direct people to use vite for react and vue projects. But to maintain backward compatibility with v6 CLI, we need to specify what projects are vite-based. 

V7 should also still respect the `--type` flag. Meaning in V7, if you do 

```
ionic start tmp-vue --type vue tabs
```

You should get the vue tabs project, with vite as the tooling.