### PR TITLE
fix(cli): ionic info returns package information

### DIFF
--- a/packages/@ionic/cli/src/lib/project/index.ts
+++ b/packages/@ionic/cli/src/lib/project/index.ts
@@ -508,7 +508,7 @@ export abstract class Project implements IProject {
     let pkgPath: string | undefined;
 
     try {
-      pkgPath = pkgName ? require.resolve(`${pkgName}/package`, { paths: compileNodeModulesPaths(this.directory) }) : this.packageJsonPath;
+      pkgPath = pkgName ? require.resolve(`${pkgName}/package.json`, { paths: compileNodeModulesPaths(this.directory) }) : this.packageJsonPath;
       pkg = await readPackageJsonFile(pkgPath);
     } catch (e: any) {
       if (logErrors) {

--- a/packages/@ionic/cli/src/lib/project/index.ts
+++ b/packages/@ionic/cli/src/lib/project/index.ts
@@ -521,7 +521,7 @@ export abstract class Project implements IProject {
 
   async requirePackageJson(pkgName?: string): Promise<PackageJson> {
     try {
-      const pkgPath = pkgName ? require.resolve(`${pkgName}/package`, { paths: compileNodeModulesPaths(this.directory) }) : this.packageJsonPath;
+      const pkgPath = pkgName ? require.resolve(`${pkgName}/package.json`, { paths: compileNodeModulesPaths(this.directory) }) : this.packageJsonPath;
       return await readPackageJsonFile(pkgPath);
     } catch (e: any) {
       if (e instanceof SyntaxError) {


### PR DESCRIPTION
## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Developers running `ionic info` against an `@ionic/angular` application on v7 will receive the following warning:

```
[WARN] Error loading @ionic/angular package.json: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package' is
       not defined by "exports" in /Users/ken/Projects/Training/tea-taster-ng/node_modules/@ionic/angular/package.json

```

Issue URL: https://github.com/ionic-team/ionic-cli/issues/4992

## What is the new behavior?

- Updates the utility for reading the `package.json` to include the full path
- `ionic info` returns the correct information for a project in both v6 and v7 (tested locally)