### PR TITLE
chore: bump to ES2021 target

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,10 +9,10 @@
     "noUnusedLocals": true,
     "pretty": true,
     "strict": true,
-    "target": "es2020",
+    "target": "ES2021",
     "types": [],
     "lib": [
-      "es2020"
+      "ES2021"
     ]
   }
 }


### PR DESCRIPTION
Our Node 16 target is compatible with ES2021 per TypeScript's [Node Target Mapping](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping) and https://node.green/#ES2021.
