### PR TITLE
Add Support for Standalone Angular Project Type

### DIFF
--- a/packages/@ionic/cli/src/lib/start.ts
+++ b/packages/@ionic/cli/src/lib/start.ts
@@ -181,7 +181,7 @@ export async function getStarterList(config: IConfig, tag = 'latest'): Promise<S
 export function getStarterProjectTypes(): string[] {
    return lodash.uniq([
     ...STARTER_TEMPLATES.map(t => t.projectType),
-    'angular-standalone' // Adicione a opção standalone aqui
+    'angular-standalone'
   ]);
 }
 

--- a/packages/@ionic/cli/src/lib/start.ts
+++ b/packages/@ionic/cli/src/lib/start.ts
@@ -179,7 +179,10 @@ export async function getStarterList(config: IConfig, tag = 'latest'): Promise<S
 }
 
 export function getStarterProjectTypes(): string[] {
-  return lodash.uniq(STARTER_TEMPLATES.map(t => t.projectType));
+   return lodash.uniq([
+    ...STARTER_TEMPLATES.map(t => t.projectType),
+    'angular-standalone' // Adicione a opção standalone aqui
+  ]);
 }
 
 export interface SupportedFramework {


### PR DESCRIPTION
Added a new 'angular-standalone' option to the list of starter project types. This option allows the creation of standalone Angular projects, distinct from other templates. Modifications were made to the getStarterProjectTypes function to include this new project type.