### PR TITLE
Removed device selection in "open" command

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/run.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/run.ts
@@ -205,7 +205,9 @@ For Android and iOS, you can setup Remote Debugging on your device with browser 
             );
           }
         } else {
-          if (targets.length > 0) {
+          if (targets.length === 1) {
+            options['target'] = targets[0].id;
+          } else if (targets.length > 1) {
             options['target'] = await this.env.prompt({
               type: 'list',
               name: 'target',


### PR DESCRIPTION
There's no need to show a device selection in `open` command when there's only one device available.

Since there's only a single possible selection, blocking `open` command waiting for user answer is worthless 😉.

NOTE: the behavior added by this PR to **ionic cli** is already present in **capacitor cli**.
