### PR TITLE
chore: deprecate ssh commands

### DIFF
--- a/packages/@ionic/cli/src/commands/ssh/add.ts
+++ b/packages/@ionic/cli/src/commands/ssh/add.ts
@@ -18,7 +18,7 @@ export class SSHAddCommand extends SSHBaseCommand implements CommandPreRun {
     return {
       name: 'add',
       type: 'global',
-      summary: 'Add an SSH public key to Ionic',
+      summary: 'Add an SSH public key to Ionic (Deprecated)',
       inputs: [
         {
           name: 'pubkey-path',

--- a/packages/@ionic/cli/src/commands/ssh/add.ts
+++ b/packages/@ionic/cli/src/commands/ssh/add.ts
@@ -1,4 +1,4 @@
-import { validators } from '@ionic/cli-framework';
+import { validators, MetadataGroup } from '@ionic/cli-framework';
 import { pathAccessible, pathExists } from '@ionic/utils-fs';
 import { expandPath, prettyPath } from '@ionic/utils-terminal';
 import * as fs from 'fs';
@@ -18,7 +18,7 @@ export class SSHAddCommand extends SSHBaseCommand implements CommandPreRun {
     return {
       name: 'add',
       type: 'global',
-      summary: 'Add an SSH public key to Ionic (Deprecated)',
+      summary: 'Add an SSH public key to Ionic',
       inputs: [
         {
           name: 'pubkey-path',
@@ -33,6 +33,7 @@ export class SSHAddCommand extends SSHBaseCommand implements CommandPreRun {
           type: Boolean,
         },
       ],
+      groups: [MetadataGroup.DEPRECATED],
     };
   }
 

--- a/packages/@ionic/cli/src/commands/ssh/delete.ts
+++ b/packages/@ionic/cli/src/commands/ssh/delete.ts
@@ -10,7 +10,7 @@ export class SSHDeleteCommand extends SSHBaseCommand implements CommandPreRun {
     return {
       name: 'delete',
       type: 'global',
-      summary: 'Delete an SSH public key from Ionic',
+      summary: 'Delete an SSH public key from Ionic (Deprecated)',
       inputs: [
         {
           name: 'key-id',

--- a/packages/@ionic/cli/src/commands/ssh/delete.ts
+++ b/packages/@ionic/cli/src/commands/ssh/delete.ts
@@ -1,4 +1,4 @@
-import { validators } from '@ionic/cli-framework';
+import { validators, MetadataGroup } from '@ionic/cli-framework';
 
 import { CommandLineInputs, CommandLineOptions, CommandMetadata, CommandPreRun } from '../../definitions';
 import { input, strong } from '../../lib/color';
@@ -10,7 +10,7 @@ export class SSHDeleteCommand extends SSHBaseCommand implements CommandPreRun {
     return {
       name: 'delete',
       type: 'global',
-      summary: 'Delete an SSH public key from Ionic (Deprecated)',
+      summary: 'Delete an SSH public key from Ionic',
       inputs: [
         {
           name: 'key-id',
@@ -18,6 +18,7 @@ export class SSHDeleteCommand extends SSHBaseCommand implements CommandPreRun {
           validators: [validators.required],
         },
       ],
+      groups: [MetadataGroup.DEPRECATED],
     };
   }
 

--- a/packages/@ionic/cli/src/commands/ssh/generate.ts
+++ b/packages/@ionic/cli/src/commands/ssh/generate.ts
@@ -15,7 +15,7 @@ export class SSHGenerateCommand extends SSHBaseCommand implements CommandPreRun 
     return {
       name: 'generate',
       type: 'global',
-      summary: 'Generates a private and public SSH key pair (Deprecated)',
+      summary: 'Generates a private and public SSH key pair',
       inputs: [
         {
           name: 'key-path',
@@ -44,6 +44,7 @@ export class SSHGenerateCommand extends SSHBaseCommand implements CommandPreRun 
           groups: [MetadataGroup.ADVANCED],
         },
       ],
+      groups: [MetadataGroup.DEPRECATED],
     };
   }
 

--- a/packages/@ionic/cli/src/commands/ssh/generate.ts
+++ b/packages/@ionic/cli/src/commands/ssh/generate.ts
@@ -15,7 +15,7 @@ export class SSHGenerateCommand extends SSHBaseCommand implements CommandPreRun 
     return {
       name: 'generate',
       type: 'global',
-      summary: 'Generates a private and public SSH key pair',
+      summary: 'Generates a private and public SSH key pair (Deprecated)',
       inputs: [
         {
           name: 'key-path',

--- a/packages/@ionic/cli/src/commands/ssh/index.ts
+++ b/packages/@ionic/cli/src/commands/ssh/index.ts
@@ -7,11 +7,13 @@ export class SSHNamespace extends Namespace {
 
     return {
       name: 'ssh',
-      summary: 'Commands for configuring SSH keys',
+      summary: 'Commands for configuring SSH keys (Deprecated)',
       description: `
 These commands help automate your SSH configuration for Ionic. As an alternative, SSH configuration can be done entirely manually by visiting your Personal Settings[^dashboard-settings-ssh-keys].
 
 To begin, run ${input('ionic ssh setup')}, which lets you use existing keys or generate new ones just for Ionic.
+
+Deprecated. Developers should configure SSH by visting their Personal Settings at https://dashboard.ionicframework.com/settings/ssh-keys.
       `,
       footnotes: [
         {

--- a/packages/@ionic/cli/src/commands/ssh/index.ts
+++ b/packages/@ionic/cli/src/commands/ssh/index.ts
@@ -14,7 +14,7 @@ These commands help automate your SSH configuration for Ionic. As an alternative
 
 To begin, run ${input('ionic ssh setup')}, which lets you use existing keys or generate new ones just for Ionic.
 
-Deprecated. Developers should configure SSH by visting their Personal Settings at https://dashboard.ionicframework.com/settings/ssh-keys.
+Deprecated. Developers should configure SSH by visiting their Personal Settings at https://dashboard.ionicframework.com/settings/ssh-keys.
       `,
       footnotes: [
         {

--- a/packages/@ionic/cli/src/commands/ssh/index.ts
+++ b/packages/@ionic/cli/src/commands/ssh/index.ts
@@ -1,3 +1,4 @@
+import { MetadataGroup } from '@ionic/cli-framework';
 import { input } from '../../lib/color';
 import { CommandMap, Namespace } from '../../lib/namespace';
 
@@ -7,7 +8,7 @@ export class SSHNamespace extends Namespace {
 
     return {
       name: 'ssh',
-      summary: 'Commands for configuring SSH keys (Deprecated)',
+      summary: 'Commands for configuring SSH keys',
       description: `
 These commands help automate your SSH configuration for Ionic. As an alternative, SSH configuration can be done entirely manually by visiting your Personal Settings[^dashboard-settings-ssh-keys].
 
@@ -21,6 +22,7 @@ Deprecated. Developers should configure SSH by visting their Personal Settings a
           url: `${dashUrl}/settings/ssh-keys`,
         },
       ],
+      groups: [MetadataGroup.DEPRECATED],
     };
   }
 

--- a/packages/@ionic/cli/src/commands/ssh/list.ts
+++ b/packages/@ionic/cli/src/commands/ssh/list.ts
@@ -1,3 +1,4 @@
+import { MetadataGroup } from '@ionic/cli-framework';
 import { columnar } from '@ionic/utils-terminal';
 
 import { COLUMNAR_OPTIONS } from '../../constants';
@@ -11,7 +12,7 @@ export class SSHListCommand extends SSHBaseCommand implements CommandPreRun {
     return {
       name: 'list',
       type: 'global',
-      summary: 'List your SSH public keys on Ionic (Deprecated)',
+      summary: 'List your SSH public keys on Ionic',
       options: [
         {
           name: 'json',
@@ -19,6 +20,7 @@ export class SSHListCommand extends SSHBaseCommand implements CommandPreRun {
           type: Boolean,
         },
       ],
+      groups: [MetadataGroup.DEPRECATED],
     };
   }
 

--- a/packages/@ionic/cli/src/commands/ssh/list.ts
+++ b/packages/@ionic/cli/src/commands/ssh/list.ts
@@ -11,7 +11,7 @@ export class SSHListCommand extends SSHBaseCommand implements CommandPreRun {
     return {
       name: 'list',
       type: 'global',
-      summary: 'List your SSH public keys on Ionic',
+      summary: 'List your SSH public keys on Ionic (Deprecated)',
       options: [
         {
           name: 'json',

--- a/packages/@ionic/cli/src/commands/ssh/setup.ts
+++ b/packages/@ionic/cli/src/commands/ssh/setup.ts
@@ -1,3 +1,4 @@
+import { MetadataGroup } from '@ionic/cli-framework';
 import { pathExists } from '@ionic/utils-fs';
 import { prettyPath } from '@ionic/utils-terminal';
 
@@ -15,7 +16,7 @@ export class SSHSetupCommand extends SSHBaseCommand {
     return {
       name: 'setup',
       type: 'global',
-      summary: 'Setup your Ionic SSH keys automatically (Deprecated)',
+      summary: 'Setup your Ionic SSH keys automatically',
       description: `
 This command offers a setup wizard for Ionic SSH keys using a series of prompts. For more control, see the commands available for managing SSH keys with the ${input('ionic ssh --help')} command. For an entirely manual approach, see ${strong('Personal Settings')} => ${strong('SSH Keys')} in the Dashboard[^dashboard-settings-ssh-keys].
 
@@ -31,6 +32,7 @@ If you are having issues setting up SSH keys, please get in touch with our Suppo
           url: 'https://ion.link/support-request',
         },
       ],
+      groups: [MetadataGroup.DEPRECATED],
     };
   }
 

--- a/packages/@ionic/cli/src/commands/ssh/setup.ts
+++ b/packages/@ionic/cli/src/commands/ssh/setup.ts
@@ -15,7 +15,7 @@ export class SSHSetupCommand extends SSHBaseCommand {
     return {
       name: 'setup',
       type: 'global',
-      summary: 'Setup your Ionic SSH keys automatically',
+      summary: 'Setup your Ionic SSH keys automatically (Deprecated)',
       description: `
 This command offers a setup wizard for Ionic SSH keys using a series of prompts. For more control, see the commands available for managing SSH keys with the ${input('ionic ssh --help')} command. For an entirely manual approach, see ${strong('Personal Settings')} => ${strong('SSH Keys')} in the Dashboard[^dashboard-settings-ssh-keys].
 

--- a/packages/@ionic/cli/src/commands/ssh/use.ts
+++ b/packages/@ionic/cli/src/commands/ssh/use.ts
@@ -13,7 +13,7 @@ export class SSHUseCommand extends SSHBaseCommand {
     return {
       name: 'use',
       type: 'global',
-      summary: 'Set your active Ionic SSH key',
+      summary: 'Set your active Ionic SSH key (Deprecated)',
       description: `
 This command modifies the SSH configuration file (${strong('~/.ssh/config')}) to set an active private key for the ${strong('git.ionicjs.com')} host. Read more about SSH configuration by running the ${input('man ssh_config')} command or by visiting online man pages[^ssh-config-docs].
 

--- a/packages/@ionic/cli/src/commands/ssh/use.ts
+++ b/packages/@ionic/cli/src/commands/ssh/use.ts
@@ -1,4 +1,4 @@
-import { validators } from '@ionic/cli-framework';
+import { validators, MetadataGroup } from '@ionic/cli-framework';
 import { fileToString, writeFile } from '@ionic/utils-fs';
 import { expandPath, prettyPath } from '@ionic/utils-terminal';
 
@@ -13,7 +13,7 @@ export class SSHUseCommand extends SSHBaseCommand {
     return {
       name: 'use',
       type: 'global',
-      summary: 'Set your active Ionic SSH key (Deprecated)',
+      summary: 'Set your active Ionic SSH key',
       description: `
 This command modifies the SSH configuration file (${strong('~/.ssh/config')}) to set an active private key for the ${strong('git.ionicjs.com')} host. Read more about SSH configuration by running the ${input('man ssh_config')} command or by visiting online man pages[^ssh-config-docs].
 
@@ -32,6 +32,7 @@ Before making changes, ${input('ionic ssh use')} will print a diff and ask for p
           validators: [validators.required],
         },
       ],
+      groups: [MetadataGroup.DEPRECATED],
     };
   }
 


### PR DESCRIPTION
This command is being deprecated in favor of configuring SSH in Personal Settings at https://dashboard.ionicframework.com/settings/ssh-keys.