### PR TITLE
Use dynamic import in hooks for type module projects

### DIFF
--- a/packages/@ionic/cli/src/lib/hooks.ts
+++ b/packages/@ionic/cli/src/lib/hooks.ts
@@ -94,7 +94,8 @@ export abstract class Hook {
   }
 
   protected async loadHookFn(p: string): Promise<HookFn | undefined> {
-    const module = require(p);
+    const [pkg] = await this.e.project.getPackageJson(undefined, { logErrors: false });
+    const module = pkg.type === 'module' ? await import(p) : require(p);
 
     if (typeof module === 'function') {
       return module;


### PR DESCRIPTION
When using ionic + vue, the hooks `serve:before` scripts defined in `ionic.config.json` cannot run.

ionic.config.json
```json
  "hooks": {
    "serve:before": ["./scripts/serve-before.js"]
  }
```

serve-before.js:
```js
export default async function (ctx) {
}
```

This setup generates the following error:
```log
[ERROR] An error occurred while running an Ionic CLI hook defined in ./ionic.config.json.
        
        Hook: serve:before
        File: /srv/libraries/app-ionic/scripts/install-custom.js
        
        Error [ERR_REQUIRE_ESM]: require() of ES Module /srv/libraries/app-ionic/scripts/serve-before.js from
        /srv/libraries/app-ionic/node_modules/@ionic/cli/lib/hooks.js not supported.
        Instead change the require of install-custom.js in
        /srv/libraries/app-ionic/node_modules/@ionic/cli/lib/hooks.js to a dynamic import() which is available in
        all CommonJS modules.
        at ServeBeforeHook.loadHookFn (/srv/libraries/app-ionic/node_modules/@ionic/cli/lib/hooks.js:73:24)
```

Switching back to `require` and `module.exports` style nodejs is not possible, because of the project `type` in the `package.json`.

```json
"type": "module",
```