### PR TITLE
Use xdg compliant directories when available

### DIFF
--- a/packages/@ionic/cli/src/commands/config/get.ts
+++ b/packages/@ionic/cli/src/commands/config/get.ts
@@ -4,10 +4,12 @@ import { columnar, prettyPath } from '@ionic/utils-terminal';
 import chalk from 'chalk';
 import * as lodash from 'lodash';
 import * as util from 'util';
+import * as path from 'path';
 
 import { COLUMNAR_OPTIONS, PROJECT_FILE } from '../../constants';
 import { CommandLineInputs, CommandLineOptions, CommandMetadata } from '../../definitions';
 import { input, strong, weak } from '../../lib/color';
+import { DEFAULT_CONFIG_DIRECTORY } from '../../lib/config';
 
 import { BaseConfigCommand, ConfigContext, getConfigValue } from './base';
 
@@ -20,7 +22,7 @@ export class ConfigGetCommand extends BaseConfigCommand {
       type: 'global',
       summary: 'Print config values',
       description: `
-This command reads and prints configuration values from the project's ${strong(projectFile)} file. It can also operate on the global CLI configuration (${strong('~/.ionic/config.json')}) using the ${input('--global')} option.
+This command reads and prints configuration values from the project's ${strong(projectFile)} file. It can also operate on the global CLI configuration (${strong(path.join(DEFAULT_CONFIG_DIRECTORY, 'config.json'))}) using the ${input('--global')} option.
 
 For nested properties, separate nest levels with dots. For example, the property name ${input('integrations.cordova')} will look in the ${strong('integrations')} object for the ${strong('cordova')} property.
 

--- a/packages/@ionic/cli/src/commands/config/index.ts
+++ b/packages/@ionic/cli/src/commands/config/index.ts
@@ -1,7 +1,9 @@
 import { prettyPath } from '@ionic/utils-terminal';
+import * as path from 'path';
 
 import { PROJECT_FILE } from '../../constants';
 import { input, strong } from '../../lib/color';
+import { DEFAULT_CONFIG_DIRECTORY } from '../../lib/config';
 import { CommandMap, Namespace } from '../../lib/namespace';
 
 export class ConfigNamespace extends Namespace {
@@ -16,7 +18,7 @@ These commands are used to programmatically read, write, and delete CLI and proj
 
 By default, these commands use your project's ${strong(prettyPath(projectFile))} file.
 
-To use these commands for the global CLI config file (${strong('~/.ionic/config.json')}), use the ${input('--global')} flag.
+To use these commands for the global CLI config file (${strong(path.join(DEFAULT_CONFIG_DIRECTORY, 'config.json'))}), use the ${input('--global')} flag.
       `,
     };
   }

--- a/packages/@ionic/cli/src/commands/config/set.ts
+++ b/packages/@ionic/cli/src/commands/config/set.ts
@@ -1,9 +1,11 @@
 import { MetadataGroup, validators } from '@ionic/cli-framework';
 import { prettyPath } from '@ionic/utils-terminal';
+import * as path from 'path';
 
 import { PROJECT_FILE } from '../../constants';
 import { CommandLineInputs, CommandLineOptions, CommandMetadata } from '../../definitions';
 import { input, strong, weak } from '../../lib/color';
+import { DEFAULT_CONFIG_DIRECTORY } from '../../lib/config';
 import { FatalException } from '../../lib/errors';
 
 import { BaseConfigCommand, getConfigValue, setConfigValue } from './base';
@@ -17,7 +19,7 @@ export class ConfigSetCommand extends BaseConfigCommand {
       type: 'global',
       summary: 'Set config values',
       description: `
-This command writes configuration values to the project's ${strong(prettyPath(projectFile))} file. It can also operate on the global CLI configuration (${strong('~/.ionic/config.json')}) using the ${input('--global')} option.
+This command writes configuration values to the project's ${strong(prettyPath(projectFile))} file. It can also operate on the global CLI configuration (${strong(path.join(DEFAULT_CONFIG_DIRECTORY, 'config.json'))}) using the ${input('--global')} option.
 
 For nested properties, separate nest levels with dots. For example, the property name ${input('integrations.cordova')} will look in the ${strong('integrations')} object for the ${strong('cordova')} property.
 

--- a/packages/@ionic/cli/src/commands/config/unset.ts
+++ b/packages/@ionic/cli/src/commands/config/unset.ts
@@ -1,9 +1,11 @@
 import { MetadataGroup, validators } from '@ionic/cli-framework';
 import { prettyPath } from '@ionic/utils-terminal';
+import * as path from 'path';
 
 import { PROJECT_FILE } from '../../constants';
 import { CommandLineInputs, CommandLineOptions, CommandMetadata } from '../../definitions';
 import { input, strong, weak } from '../../lib/color';
+import { DEFAULT_CONFIG_DIRECTORY } from '../../lib/config';
 import { FatalException } from '../../lib/errors';
 
 import { BaseConfigCommand, getConfigValue, unsetConfigValue } from './base';
@@ -17,7 +19,7 @@ export class ConfigUnsetCommand extends BaseConfigCommand {
       type: 'global',
       summary: 'Delete config values',
       description: `
-This command deletes configuration values from the project's ${strong(prettyPath(projectFile))} file. It can also operate on the global CLI configuration (${strong('~/.ionic/config.json')}) using the ${input('--global')} option.
+This command deletes configuration values from the project's ${strong(prettyPath(projectFile))} file. It can also operate on the global CLI configuration (${strong(path.join(DEFAULT_CONFIG_DIRECTORY, 'config.json'))}) using the ${input('--global')} option.
 
 For nested properties, separate nest levels with dots. For example, the property name ${input('integrations.cordova')} will look in the ${strong('integrations')} object for the ${strong('cordova')} property.
 

--- a/packages/@ionic/cli/src/commands/ssl/generate.ts
+++ b/packages/@ionic/cli/src/commands/ssl/generate.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 
 import { CommandLineInputs, CommandLineOptions, CommandMetadata, CommandPreRun } from '../../definitions';
 import { input, strong } from '../../lib/color';
+import { DEFAULT_CONFIG_DIRECTORY } from '../../lib/config';
 import { FatalException } from '../../lib/errors';
 
 import { SSLBaseCommand } from './base';
@@ -26,19 +27,22 @@ interface OpenSSLConfig {
   commonName: string;
 }
 
-const DEFAULT_KEY_FILE = '.ionic/ssl/key.pem';
-const DEFAULT_CERT_FILE = '.ionic/ssl/cert.pem';
-
 export class SSLGenerateCommand extends SSLBaseCommand implements CommandPreRun {
+  getDefaultSslDirectory() {
+    return this.project ? path.resolve(this.project.directory, '.ionic', 'ssl') :
+      path.resolve(DEFAULT_CONFIG_DIRECTORY, 'ssl');
+  }
+
   getDefaultKeyPath() {
-    return path.resolve(this.project ? this.project.directory : '', DEFAULT_KEY_FILE);
+    return path.resolve(this.getDefaultSslDirectory(), 'key.pem');
   }
 
   getDefaultCertPath() {
-    return path.resolve(this.project ? this.project.directory : '', DEFAULT_CERT_FILE);
+    return path.resolve(this.getDefaultSslDirectory(), 'cert.pem');
   }
 
   async getMetadata(): Promise<CommandMetadata> {
+    const defaultSslDirectory = prettyPath(this.getDefaultSslDirectory())
     const defaultKeyPath = prettyPath(this.getDefaultKeyPath());
     const defaultCertPath = prettyPath(this.getDefaultCertPath());
 
@@ -52,7 +56,7 @@ Uses OpenSSL to create a self-signed certificate for ${strong('localhost')} (by 
 
 After the certificate is generated, you will still need to add it to your system or browser as a trusted certificate.
 
-The default directory for ${input('--key-path')} and ${input('--cert-path')} is ${input('.ionic/ssl/')}.
+The default directory for ${input('--key-path')} and ${input('--cert-path')} is ${input(defaultSslDirectory)}.
 
 Deprecated. Developers should generate an SSL certificate locally and then configure it using their project tooling such as Vite or Angular CLI.
       `,

--- a/packages/@ionic/cli/src/lib/config.ts
+++ b/packages/@ionic/cli/src/lib/config.ts
@@ -1,6 +1,7 @@
 import { BaseConfig, BaseConfigOptions, MetadataGroup, ParsedArgs, metadataOptionsToParseArgsOptions, parseArgs } from '@ionic/cli-framework';
 import * as os from 'os';
 import * as path from 'path';
+import * as fs from 'fs';
 
 import { CommandMetadataOption, ConfigFile, CreateRequestOptions, IConfig, OAuthServerConfig } from '../definitions';
 
@@ -53,7 +54,18 @@ export const GLOBAL_OPTIONS: readonly CommandMetadataOption[] = [
 ];
 
 export const CONFIG_FILE = 'config.json';
-export const DEFAULT_CONFIG_DIRECTORY = path.resolve(os.homedir(), '.ionic');
+export const DEFAULT_CONFIG_DIRECTORY = findDefaultConfigDir();
+
+function findDefaultConfigDir() {
+  const fallback = path.resolve(os.homedir(), '.ionic');
+  if (fs.existsSync(fallback)) return fallback;
+
+  if (process.env.XDG_CONFIG_HOME) {
+    return path.resolve(process.env.XDG_CONFIG_HOME, 'ionic');
+  } else {
+    return fallback;
+  }
+}
 
 export class Config extends BaseConfig<ConfigFile> implements IConfig {
   constructor(p: string, options?: BaseConfigOptions) {


### PR DESCRIPTION
This PR makes the CLI use the [standard config directory as per xdg spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) when `XDG_CONFIG_HOME` is set.

As to not break existing installations, this behavior is overridden if `~/.ionic` already exists and will fall back to the previous behavior.