### PR TITLE
Add more explicit log on 'ionic cap build' error

### DIFF
--- a/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
+++ b/packages/@ionic/cli/src/lib/integrations/capacitor/index.ts
@@ -187,6 +187,7 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
   });
 
   getCapacitorCLIConfig = lodash.memoize(async (): Promise<CapacitorCLIConfig | undefined> => {
+    const command = 'capacitor'
     const args = ['config', '--json'];
 
     debug('Getting config with Capacitor CLI: %O', args);
@@ -201,10 +202,13 @@ export class Integration extends BaseIntegration<ProjectIntegration> {
         } catch (err) {
           throw err;
         }
-      })('capacitor', args, { cwd: this.root })
+      })(command, args, { cwd: this.root })
     } catch (error) {
       if ((error as any).code === 'ERR_SUBPROCESS_COMMAND_NOT_FOUND') {
         throw new Error(`Capacitor command not found. Is the Capacitor CLI installed? (npm i -D @capacitor/cli)`);
+      } else if ((error as any).output) {
+        const errorLog = "\n> " + ((error as any).output as string).replaceAll("\n", "\n> ");
+        throw new Error(`'${command} ${args.join(" ")}' failed with: ${errorLog}`);
       } else {
         throw new Error((error as any).message);
       }


### PR DESCRIPTION
before
```bash
Error: Non-zero exit from subprocess.
    at Integration.<anonymous> (/usr/lib/node_modules/@ionic/cli/lib/integrations/capacitor/index.js:53:27)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async BuildCommand.getInstalledPlatforms (/usr/lib/node_modules/@ionic/cli/commands/capacitor/base.js:114:21)
    at async BuildCommand.isPlatformInstalled (/usr/lib/node_modules/@ionic/cli/commands/capacitor/base.js:130:27)
    at async BuildCommand.checkForPlatformInstallation (/usr/lib/node_modules/@ionic/cli/commands/capacitor/base.js:228:19)
    at async BuildCommand.preRun (/usr/lib/node_modules/@ionic/cli/commands/capacitor/build.js:95:9)
    at async BuildCommand.execute (/usr/lib/node_modules/@ionic/cli/lib/command.js:65:13)
    at async Executor.run (/usr/lib/node_modules/@ionic/cli/lib/executor.js:55:9)
    at async Executor.execute (/usr/lib/node_modules/@ionic/cli/node_modules/@ionic/cli-framework/lib/executor.js:71:13)
    at async Object.run (/usr/lib/node_modules/@ionic/cli/index.js:111:9)
```

after
```bash
Error: 'capacitor config --json' failed with: 
> [error] Parsing capacitor.config.ts failed.
>         
>         Error: EACCES: permission denied, open '/home/git/fems/ui/capacitor.config.ts'
>         at readFileSync (node:fs:455:20)
>         at require.extensions..ts (/home/git/fems/ui/node_modules/@capacitor/cli/dist/util/node.js:15:54)
>         at Module.load (node:internal/modules/cjs/loader:1205:32)
>         at Module._load (node:internal/modules/cjs/loader:1021:12)
>         at Module.require (node:internal/modules/cjs/loader:1230:19)
>         at require (node:internal/modules/helpers:179:18)
>         at requireTS (/home/git/fems/ui/node_modules/@capacitor/cli/dist/util/node.js:37:15)
>         at loadExtConfigTS (/home/git/fems/ui/node_modules/@capacitor/cli/dist/config.js:90:54)
>         at loadExtConfig (/home/git/fems/ui/node_modules/@capacitor/cli/dist/config.js:126:16)
>         at async loadConfig (/home/git/fems/ui/node_modules/@capacitor/cli/dist/config.js:26:18)
> 
    at Integration.<anonymous> (/usr/lib/node_modules/@ionic/cli/lib/integrations/capacitor/index.js:57:27)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async BuildCommand.getInstalledPlatforms (/usr/lib/node_modules/@ionic/cli/commands/capacitor/base.js:114:21)
    at async BuildCommand.isPlatformInstalled (/usr/lib/node_modules/@ionic/cli/commands/capacitor/base.js:130:27)
    at async BuildCommand.checkForPlatformInstallation (/usr/lib/node_modules/@ionic/cli/commands/capacitor/base.js:228:19)
    at async BuildCommand.preRun (/usr/lib/node_modules/@ionic/cli/commands/capacitor/build.js:95:9)
    at async BuildCommand.execute (/usr/lib/node_modules/@ionic/cli/lib/command.js:65:13)
    at async Executor.run (/usr/lib/node_modules/@ionic/cli/lib/executor.js:55:9)
    at async Executor.execute (/usr/lib/node_modules/@ionic/cli/node_modules/@ionic/cli-framework/lib/executor.js:71:13)
    at async Object.run (/usr/lib/node_modules/@ionic/cli/index.js:111:9)
```