### PR TITLE
Update project.ts, to be compatible with latest cordova-ios v7

### DIFF
--- a/packages/@ionic/cli/src/lib/integrations/cordova/project.ts
+++ b/packages/@ionic/cli/src/lib/integrations/cordova/project.ts
@@ -10,9 +10,9 @@ import { FatalException } from '../../errors';
 
 const debug = Debug('ionic:lib:cordova:project');
 
-const CORDOVA_ANDROID_PACKAGE_PATH = 'platforms/android/app/build/outputs/apk/';
-const CORDOVA_IOS_SIMULATOR_PACKAGE_PATH = 'platforms/ios/build/emulator';
-const CORDOVA_IOS_DEVICE_PACKAGE_PATH = 'platforms/ios/build/device';
+const CORDOVA_ANDROID_PACKAGE_PATH = process.env.CORDOVA_ANDROID_PACKAGE_PATH ?? 'platforms/android/app/build/outputs/apk/';
+const CORDOVA_IOS_SIMULATOR_PACKAGE_PATH = proccess.env.CORDOVA_IOS_SIMULATOR_PACKAGE_PATH ?? 'platforms/ios/build/emulator';
+const CORDOVA_IOS_DEVICE_PACKAGE_PATH = process.env.CORDOVA_IOS_DEVICE_PACKAGE_PATH ?? 'platforms/ios/build/device';
 
 export async function getPlatforms(projectDir: string): Promise<string[]> {
   const platformsDir = path.resolve(projectDir, 'platforms');


### PR DESCRIPTION
Provide a way of modifying relative paths to most recently built APK or IPA files, with environment variables. `cordova-ios v7` provided a breaking change, which sets the paths of built assets to correspond to ones used by XCode by default:
- was `device` -> now `Debug-iphoneos`
- was `simulator` -> now `Debug-iphonesimulator`