### PR TITLE
when livereload-url is specified, the server is not started.

### DIFF
--- a/packages/@ionic/cli/src/commands/capacitor/base.ts
+++ b/packages/@ionic/cli/src/commands/capacitor/base.ts
@@ -236,8 +236,8 @@ export abstract class CapacitorCommand extends Command {
 
       let serverUrl = options['livereload-url'] ? String(options['livereload-url']) : undefined;
 
+      const details = await runner.run(runnerOpts);
       if (!serverUrl) {
-        const details = await runner.run(runnerOpts);
         serverUrl = `${details.protocol || 'http'}://${details.externalAddress}:${details.port}`;
       }
 


### PR DESCRIPTION
move this one line out of the condition check, the serve is started no matter whether livereload-url is specified or not.

I think that this is a very simple fix.