### PR TITLE
fix: restrict installerArgs push to npm client only

### DIFF
--- a/packages/@ionic/cli/src/lib/utils/npm.ts
+++ b/packages/@ionic/cli/src/lib/utils/npm.ts
@@ -158,7 +158,7 @@ export async function pkgManagerArgs(npmClient: NpmClient, options: PkgManagerOp
   }
 
   if (cmd === 'run' && options.script && options.scriptArgs && options.scriptArgs.length > 0) {
-    if (npmClient === 'npm' || npmClient === 'pnpm') {
+    if (npmClient === 'npm') {
       installerArgs.push('--');
     }
 


### PR DESCRIPTION
Currently, when pnpm is set as the package manager, '--' is inserted before arguments that are meant to be passed on to a script being run. This is incorrect.

As a result, for example, `ionic cap run ios --open --livereload --external`, when run with vue/vite, ends up executing `pnpm run ionic:serve -- --host=0.0.0.0 --port=8100`, and because pnpm does not recognize `--`, the `host` and `port` options are not recognized.